### PR TITLE
Ensure BotBuilder module handles optional imports safely

### DIFF
--- a/src/__tests__/app.module.spec.ts
+++ b/src/__tests__/app.module.spec.ts
@@ -1,0 +1,58 @@
+import { Global, Module } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import { PublisherService } from 'otostogan-nest-logger';
+import { BotBuilder } from '../app.module';
+import { PrismaService } from '../prisma/prisma.service';
+import { BuilderService } from '../builder/builder.service';
+
+jest.mock('node-telegram-bot-api', () => {
+    return jest.fn().mockImplementation(() => ({
+        on: jest.fn(),
+        sendMessage: jest.fn().mockResolvedValue(undefined),
+        stopPolling: jest.fn().mockResolvedValue(undefined),
+    }));
+});
+
+const loggerMock = {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+};
+
+@Global()
+@Module({
+    providers: [
+        {
+            provide: PublisherService,
+            useValue: loggerMock,
+        },
+    ],
+    exports: [PublisherService],
+})
+class LoggerMockModule {}
+
+describe('BotBuilder module', () => {
+    it('creates module without explicit imports', async () => {
+        const moduleRef = await Test.createTestingModule({
+            imports: [
+                LoggerMockModule,
+                BotBuilder.forRootAsync({
+                    useFactory: async () => ({
+                        TG_BOT_TOKEN: 'test-token',
+                    }),
+                }),
+            ],
+        })
+            .overrideProvider(PrismaService)
+            .useValue({
+                $connect: jest.fn(),
+                $disconnect: jest.fn(),
+            })
+            .compile();
+
+        expect(moduleRef).toBeDefined();
+        expect(moduleRef.get(BuilderService)).toBeInstanceOf(BuilderService);
+
+        await moduleRef.close();
+    });
+});

--- a/src/app.interface.ts
+++ b/src/app.interface.ts
@@ -196,6 +196,7 @@ export interface IBotBuilderOptions {
 
 export interface IBotBuilderModuleAsyncOptions
     extends Pick<ModuleMetadata, 'imports'> {
+    imports?: ModuleMetadata['imports'];
     useFactory: (
         ...args: any[]
     ) =>


### PR DESCRIPTION
## Summary
- ensure `IBotBuilderModuleAsyncOptions` explicitly treats `imports` as optional to match the safe fallback in the module definition
- add a Nest testing spec that compiles `BotBuilder.forRootAsync` without providing the `imports` option, using mocks for external dependencies

## Testing
- npm test
- npm test -- --runTestsByPath src/__tests__/app.module.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68cdbe5e5d3c8328a34e50d9d0e3edbd