### PR TITLE
Refactor bot runtime into modular services

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,34 @@ await builderService.goToInitialPage('primary', chatId);
 await builderService.goToPage('secondary', chatId, 'start');
 ```
 
+### Runtime customization
+
+`BotRuntime` now composes its behavior from three dedicated services:
+
+- `SessionManager` controls session retrieval and persistence.
+- `PageNavigator` resolves pages, keyboards and middleware execution.
+- `PersistenceGateway` encapsulates Prisma synchronization.
+
+All three services and their factory helpers are exported from the package for advanced scenarios:
+
+```ts
+import {
+    BotRuntime,
+    createSessionManager,
+    createPageNavigator,
+    createPersistenceGateway,
+} from 'tg-bot-builder';
+
+const runtime = new BotRuntime(options, logger, prisma, {
+    sessionManagerFactory: ({ sessionStorage }) =>
+        createSessionManager({ sessionStorage }),
+    pageNavigatorFactory: (deps) => createPageNavigator(deps),
+    persistenceGatewayFactory: (deps) => createPersistenceGateway(deps),
+});
+```
+
+Providing custom factories allows full control over session storage, page rendering logic or database synchronization without modifying `BotRuntime` itself.
+
 ## Project setup
 
 ```bash

--- a/src/builder/bot-runtime.ts
+++ b/src/builder/bot-runtime.ts
@@ -1,63 +1,43 @@
-import { ValidationError } from 'yup';
 import {
     IBotBuilderContext,
     IBotBuilderOptions,
-    IBotKeyboardConfig,
-    IBotPageNavigationOptions,
-    IBotPageMiddlewareConfig,
     IBotPage,
-    IBotPageMiddlewareResult,
+    IBotPageNavigationOptions,
     IBotSessionState,
     IBotSessionStorage,
-    IPrismaStepState,
-    IPrismaUser,
-    TBotKeyboardMarkup,
-    TBotPageContent,
-    TBotPageContentResult,
     TBotPageIdentifier,
-    TBotPageMiddlewareHandlerResult,
-    TPrismaJsonValue,
 } from '../app.interface';
 import { PublisherService } from 'otostogan-nest-logger';
 import TelegramBot = require('node-telegram-bot-api');
 import type { PrismaClient } from '@prisma/client/extension';
-
-const DEFAULT_PAGE_MIDDLEWARE_REJECTION_MESSAGE =
-    'Access to this page is denied..';
-
-interface IChatSessionState {
-    pageId?: TBotPageIdentifier;
-    data: IBotSessionState;
-    user?: TelegramBot.User;
-}
-
-interface IBuilderContextOptions {
-    chatId: TelegramBot.ChatId;
-    session: IChatSessionState;
-    message?: TelegramBot.Message;
-    metadata?: TelegramBot.Metadata;
-    user?: TelegramBot.User;
-    database?: IContextDatabaseState;
-}
-
-interface IContextDatabaseState {
-    user?: IPrismaUser;
-    stepState?: IPrismaStepState;
-}
-
-interface IStepHistoryEntry {
-    pageId: string;
-    value: TPrismaJsonValue | null;
-    timestamp: string;
-}
-
-interface IValidationResult {
-    valid: boolean;
-    errorMessage?: string;
-}
+import {
+    PageNavigator,
+    PageNavigatorFactoryOptions,
+} from './runtime/page-navigator';
+import {
+    IChatSessionState,
+    SessionManager,
+    SessionManagerFactoryOptions,
+} from './runtime/session-manager';
+import {
+    IContextDatabaseState,
+    PersistenceGateway,
+    PersistenceGatewayFactoryOptions,
+} from './runtime/persistence-gateway';
+import { createPageNavigator } from './runtime/page-navigator';
+import { createSessionManager } from './runtime/session-manager';
+import { createPersistenceGateway } from './runtime/persistence-gateway';
 
 export interface IBotRuntimeOptions extends IBotBuilderOptions {
     id: string;
+}
+
+export interface BotRuntimeDependencies {
+    pageNavigatorFactory?: (options: PageNavigatorFactoryOptions) => PageNavigator;
+    sessionManagerFactory?: (options: SessionManagerFactoryOptions) => SessionManager;
+    persistenceGatewayFactory?: (
+        options: PersistenceGatewayFactoryOptions,
+    ) => PersistenceGateway;
 }
 
 export function normalizeBotOptions(
@@ -97,72 +77,68 @@ export function normalizeBotOptions(
     } as IBotRuntimeOptions;
 }
 
+interface IBuilderContextOptions {
+    chatId: TelegramBot.ChatId;
+    session: IChatSessionState;
+    message?: TelegramBot.Message;
+    metadata?: TelegramBot.Metadata;
+    user?: TelegramBot.User;
+    database?: IContextDatabaseState;
+}
+
 export class BotRuntime {
     public readonly id: string;
     public readonly token: string;
     public readonly bot: TelegramBot;
 
-    private readonly pages: IBotPage[];
-    private readonly pagesMap: Map<TBotPageIdentifier, IBotPage>;
-    private readonly keyboardsMap: Map<string, IBotKeyboardConfig>;
-    private readonly persistentKeyboards: IBotKeyboardConfig[];
-    private readonly pageMiddlewaresMap: Map<string, IBotPageMiddlewareConfig>;
-    private initialPageId?: TBotPageIdentifier;
-    private readonly sessionStorage: IBotSessionStorage<IChatSessionState>;
-    private readonly sessionCache: Map<string, IChatSessionState> = new Map();
-    private readonly prisma?: PrismaClient;
-    private readonly slug: string;
+    private readonly logger: PublisherService;
+    private readonly pageNavigator: PageNavigator;
+    private readonly sessionManager: SessionManager;
+    private readonly persistenceGateway: PersistenceGateway;
     private readonly helperServices: Record<string, unknown>;
 
     constructor(
         options: IBotRuntimeOptions,
-        private readonly logger: PublisherService,
-        private readonly prismaService?: PrismaClient,
+        logger: PublisherService,
+        prismaService?: PrismaClient,
+        dependencies: BotRuntimeDependencies = {},
     ) {
         this.id = options.id;
         this.token = options.TG_BOT_TOKEN;
         this.bot = new TelegramBot(this.token, { polling: true });
+        this.logger = logger;
 
-        this.pages = [];
-        this.pagesMap = new Map();
-        this.initialPageId = options.initialPageId;
-        this.registerPages(options.pages ?? []);
-
-        const keyboards = options.keyboards ?? [];
-        this.keyboardsMap = new Map(
-            keyboards
-                .filter((keyboard) => !keyboard.persistent)
-                .map((keyboard) => [keyboard.id, keyboard]),
-        );
-        this.persistentKeyboards = keyboards.filter(
-            (keyboard) => keyboard.persistent,
-        );
-
-        const pageMiddlewares = options.pageMiddlewares ?? [];
-        this.pageMiddlewaresMap = new Map(
-            pageMiddlewares
-                .filter(
-                    (
-                        middleware,
-                    ): middleware is IBotPageMiddlewareConfig & {
-                        name: string;
-                    } =>
-                        typeof middleware.name === 'string' &&
-                        middleware.name.length > 0,
-                )
-                .map((middleware) => [middleware.name, middleware]),
-        );
-
-        this.prisma = options.prisma ?? prismaService;
-        this.slug = options.slug ?? 'default';
         this.helperServices = options.services ?? {};
 
-        const providedSessionStorage = options.sessionStorage as unknown as
-            | IBotSessionStorage<IChatSessionState>
+        const providedSessionStorage = options.sessionStorage as
+            | IBotSessionStorage<IChatSessionState | IBotSessionState>
             | undefined;
 
-        this.sessionStorage =
-            providedSessionStorage ?? this.createDefaultSessionStorage();
+        const sessionManagerFactory =
+            dependencies.sessionManagerFactory ?? createSessionManager;
+        this.sessionManager = sessionManagerFactory({
+            sessionStorage: providedSessionStorage,
+        });
+
+        const prisma = options.prisma ?? prismaService;
+        const persistenceGatewayFactory =
+            dependencies.persistenceGatewayFactory ?? createPersistenceGateway;
+        this.persistenceGateway = persistenceGatewayFactory({
+            prisma,
+            slug: options.slug ?? 'default',
+        });
+
+        const pageNavigatorFactory =
+            dependencies.pageNavigatorFactory ?? createPageNavigator;
+        this.pageNavigator = pageNavigatorFactory({
+            bot: this.bot,
+            logger: this.logger,
+            initialPageId: options.initialPageId,
+            keyboards: options.keyboards ?? [],
+            pageMiddlewares: options.pageMiddlewares ?? [],
+        });
+
+        this.pageNavigator.registerPages(options.pages ?? []);
 
         this.logger.info(`BotBuilder runtime "${this.id}" initialized`);
 
@@ -170,40 +146,7 @@ export class BotRuntime {
     }
 
     public registerPages(pages: IBotPage[]): void {
-        if (!Array.isArray(pages) || pages.length === 0) {
-            return;
-        }
-
-        for (const page of pages) {
-            if (!page || typeof page.id !== 'string' || page.id.length === 0) {
-                this.logger.warn(
-                    'Attempted to register a page without a valid identifier',
-                );
-                continue;
-            }
-
-            const existingIndex = this.pages.findIndex(
-                (registeredPage) => registeredPage.id === page.id,
-            );
-
-            if (existingIndex >= 0) {
-                this.pages[existingIndex] = page;
-            } else {
-                this.pages.push(page);
-            }
-
-            this.pagesMap.set(page.id, page);
-        }
-
-        if (!this.initialPageId && this.pages.length > 0) {
-            this.initialPageId = this.pages[0].id;
-        }
-
-        if (this.initialPageId && !this.pagesMap.has(this.initialPageId)) {
-            this.logger.warn(
-                `Initial page with id "${this.initialPageId}" not found among registered pages`,
-            );
-        }
+        this.pageNavigator.registerPages(pages);
     }
 
     public async goToPage(
@@ -211,7 +154,7 @@ export class BotRuntime {
         pageId: TBotPageIdentifier,
         options?: IBotPageNavigationOptions,
     ): Promise<void> {
-        const page = this.pagesMap.get(pageId);
+        const page = this.pageNavigator.resolvePage(pageId);
         if (!page) {
             this.logger.warn(
                 `Page with id "${pageId}" not found for chat ${chatId}`,
@@ -219,7 +162,7 @@ export class BotRuntime {
             return;
         }
 
-        const session = await this.getSession(chatId);
+        const session = await this.sessionManager.getSession(chatId);
 
         if (options?.resetState) {
             session.data = {};
@@ -238,9 +181,9 @@ export class BotRuntime {
         }
 
         session.pageId = page.id;
-        await this.saveSession(chatId, session);
+        await this.sessionManager.saveSession(chatId, session);
 
-        const database = await this.ensureDatabaseState(
+        const database = await this.persistenceGateway.ensureDatabaseState(
             chatId,
             session,
             options?.message,
@@ -256,7 +199,7 @@ export class BotRuntime {
             database,
         });
 
-        await this.renderPage(page, context);
+        await this.pageNavigator.renderPage(page, context);
     }
 
     private registerHandlers(): void {
@@ -269,11 +212,11 @@ export class BotRuntime {
     ): Promise<void> => {
         try {
             const chatId = message.chat.id;
-            const session = await this.getSession(chatId);
+            const session = await this.sessionManager.getSession(chatId);
             if (message.from) {
                 session.user = message.from;
             }
-            let database = await this.ensureDatabaseState(
+            let database = await this.persistenceGateway.ensureDatabaseState(
                 chatId,
                 session,
                 message,
@@ -289,7 +232,7 @@ export class BotRuntime {
             });
 
             if (!session.pageId) {
-                const initialPage = this.resolveInitialPage();
+                const initialPage = this.pageNavigator.resolveInitialPage();
                 if (!initialPage) {
                     this.logger.warn('No initial page configured');
                     return;
@@ -297,8 +240,8 @@ export class BotRuntime {
 
                 session.pageId = initialPage.id;
                 session.data = session.data ?? {};
-                await this.saveSession(chatId, session);
-                database = await this.ensureDatabaseState(
+                await this.sessionManager.saveSession(chatId, session);
+                database = await this.persistenceGateway.ensureDatabaseState(
                     chatId,
                     session,
                     message,
@@ -311,11 +254,11 @@ export class BotRuntime {
                     metadata,
                     database,
                 });
-                await this.renderPage(initialPage, context);
+                await this.pageNavigator.renderPage(initialPage, context);
                 return;
             }
 
-            const currentPage = this.pagesMap.get(session.pageId);
+            const currentPage = this.pageNavigator.resolvePage(session.pageId);
             if (!currentPage) {
                 this.logger.warn(
                     `Page with id "${session.pageId}" not found for chat ${chatId}`,
@@ -324,8 +267,8 @@ export class BotRuntime {
                 return;
             }
 
-            const value = this.extractMessageValue(message);
-            const validationResult = await this.validatePageValue(
+            const value = this.pageNavigator.extractMessageValue(message);
+            const validationResult = await this.pageNavigator.validatePageValue(
                 currentPage,
                 value,
                 context,
@@ -336,7 +279,7 @@ export class BotRuntime {
                     validationResult.errorMessage ??
                     'Введены некорректные данные, попробуйте ещё раз.';
                 await this.bot.sendMessage(chatId, errorMessage);
-                await this.renderPage(
+                await this.pageNavigator.renderPage(
                     currentPage,
                     this.createContext({ chatId, session, database }),
                 );
@@ -345,7 +288,7 @@ export class BotRuntime {
 
             session.data[currentPage.id] = value;
 
-            const updatedStepState = await this.persistStepProgress(
+            const updatedStepState = await this.persistenceGateway.persistStepProgress(
                 database.stepState,
                 currentPage.id,
                 value,
@@ -366,7 +309,7 @@ export class BotRuntime {
                 );
             }
 
-            const nextPageId = await this.resolveNextPageId(
+            const nextPageId = await this.pageNavigator.resolveNextPageId(
                 currentPage,
                 this.createContext({
                     chatId,
@@ -379,22 +322,22 @@ export class BotRuntime {
 
             if (!nextPageId) {
                 session.pageId = undefined;
-                await this.saveSession(chatId, session);
-                await this.updateStepStateCurrentPage(
+                await this.sessionManager.saveSession(chatId, session);
+                await this.persistenceGateway.updateStepStateCurrentPage(
                     database.stepState,
                     undefined,
                 );
                 return;
             }
 
-            const nextPage = this.pagesMap.get(nextPageId);
+            const nextPage = this.pageNavigator.resolvePage(nextPageId);
             if (!nextPage) {
                 this.logger.warn(
                     `Next page with id "${nextPageId}" not found for chat ${chatId}`,
                 );
                 session.pageId = undefined;
-                await this.saveSession(chatId, session);
-                await this.updateStepStateCurrentPage(
+                await this.sessionManager.saveSession(chatId, session);
+                await this.persistenceGateway.updateStepStateCurrentPage(
                     database.stepState,
                     undefined,
                 );
@@ -402,17 +345,18 @@ export class BotRuntime {
             }
 
             session.pageId = nextPage.id;
-            await this.saveSession(chatId, session);
+            await this.sessionManager.saveSession(chatId, session);
 
-            const nextStepState = await this.updateStepStateCurrentPage(
-                database.stepState,
-                nextPage.id,
-            );
+            const nextStepState =
+                await this.persistenceGateway.updateStepStateCurrentPage(
+                    database.stepState,
+                    nextPage.id,
+                );
             if (nextStepState) {
                 database.stepState = nextStepState;
             }
 
-            await this.renderPage(
+            await this.pageNavigator.renderPage(
                 nextPage,
                 this.createContext({ chatId, session, database }),
             );
@@ -425,81 +369,19 @@ export class BotRuntime {
         }
     };
 
-    private async getSession(
-        chatId: TelegramBot.ChatId,
-    ): Promise<IChatSessionState> {
-        const key = chatId.toString();
-        const cached = this.sessionCache.get(key);
-        if (cached) {
-            return cached;
-        }
-
-        const stored = await this.sessionStorage.get(chatId);
-        const session = this.normalizeSessionState(stored) ?? {
-            pageId: undefined,
-            data: {},
-        };
-
-        this.sessionCache.set(key, session);
-        return session;
-    }
-
-    private normalizeSessionState(
-        stored?: IChatSessionState | IBotSessionState | null,
-    ): IChatSessionState | undefined {
-        if (!stored) {
-            return undefined;
-        }
-
-        if (this.isChatSessionState(stored)) {
-            stored.data = stored.data ?? {};
-            return stored;
-        }
-
-        if (this.isSessionState(stored)) {
-            return {
-                pageId: undefined,
-                data: stored,
-            };
-        }
-
-        return undefined;
-    }
-
-    private isChatSessionState(value: unknown): value is IChatSessionState {
-        return (
-            typeof value === 'object' &&
-            value !== null &&
-            'data' in value &&
-            !Array.isArray((value as { data?: unknown }).data)
-        );
-    }
-
-    private isSessionState(value: unknown): value is IBotSessionState {
-        return (
-            typeof value === 'object' && value !== null && !Array.isArray(value)
-        );
-    }
-
-    private async saveSession(
-        chatId: TelegramBot.ChatId,
-        session: IChatSessionState,
-    ): Promise<void> {
-        const key = chatId.toString();
-        this.sessionCache.set(key, session);
-        await this.sessionStorage.set(chatId, session);
-    }
-
     private async resetToInitialPage(
         chatId: TelegramBot.ChatId,
         session: IChatSessionState,
     ): Promise<void> {
-        const initialPage = this.resolveInitialPage();
+        const initialPage = this.pageNavigator.resolveInitialPage();
         if (!initialPage) {
             session.pageId = undefined;
-            await this.saveSession(chatId, session);
-            const database = await this.ensureDatabaseState(chatId, session);
-            await this.updateStepStateCurrentPage(
+            await this.sessionManager.saveSession(chatId, session);
+            const database = await this.persistenceGateway.ensureDatabaseState(
+                chatId,
+                session,
+            );
+            await this.persistenceGateway.updateStepStateCurrentPage(
                 database.stepState,
                 undefined,
             );
@@ -507,34 +389,19 @@ export class BotRuntime {
         }
 
         session.pageId = initialPage.id;
-        await this.saveSession(chatId, session);
+        await this.sessionManager.saveSession(chatId, session);
 
-        const database = await this.ensureDatabaseState(
+        const database = await this.persistenceGateway.ensureDatabaseState(
             chatId,
             session,
             undefined,
             initialPage.id,
         );
 
-        await this.renderPage(
+        await this.pageNavigator.renderPage(
             initialPage,
             this.createContext({ chatId, session, database }),
         );
-    }
-
-    private resolveInitialPage(): IBotPage | undefined {
-        if (this.initialPageId) {
-            const initialPage = this.pagesMap.get(this.initialPageId);
-            if (initialPage) {
-                return initialPage;
-            }
-
-            this.logger.warn(
-                `Initial page with id "${this.initialPageId}" not found among registered pages`,
-            );
-        }
-
-        return this.pages[0];
     }
 
     private createContext(options: IBuilderContextOptions): IBotBuilderContext {
@@ -549,516 +416,9 @@ export class BotRuntime {
             metadata: options.metadata,
             session: options.session.data,
             user,
-            prisma: this.prisma,
+            prisma: this.persistenceGateway.prisma,
             db: options.database,
             services: this.helperServices,
-        };
-    }
-
-    private extractMessageValue(message: TelegramBot.Message): unknown {
-        if (typeof message.text === 'string') {
-            return message.text;
-        }
-
-        if (typeof message.caption === 'string') {
-            return message.caption;
-        }
-
-        if (message.contact) {
-            return message.contact;
-        }
-
-        if (message.location) {
-            return message.location;
-        }
-
-        if (message.photo) {
-            return message.photo;
-        }
-
-        if (message.document) {
-            return message.document;
-        }
-
-        return message;
-    }
-
-    private async validatePageValue(
-        page: IBotPage,
-        value: unknown,
-        context: IBotBuilderContext,
-    ): Promise<IValidationResult> {
-        if (page.yup) {
-            try {
-                await page.yup.validate(value, { context });
-            } catch (error) {
-                if (error instanceof ValidationError) {
-                    return { valid: false, errorMessage: error.message };
-                }
-
-                return {
-                    valid: false,
-                    errorMessage: 'Ошибка проверки данных, попробуйте ещё раз.',
-                };
-            }
-        }
-
-        if (page.validate) {
-            try {
-                const isValid = await page.validate(value, context);
-                if (!isValid) {
-                    return {
-                        valid: false,
-                        errorMessage:
-                            'Введены некорректные данные, попробуйте ещё раз.',
-                    };
-                }
-            } catch (error) {
-                const message =
-                    error instanceof Error
-                        ? error.message
-                        : 'Ошибка проверки данных, попробуйте ещё раз.';
-                return { valid: false, errorMessage: message };
-            }
-        }
-
-        return { valid: true };
-    }
-
-    private async resolveNextPageId(
-        currentPage: IBotPage,
-        context: IBotBuilderContext,
-    ): Promise<TBotPageIdentifier | undefined> {
-        if (currentPage.next) {
-            const resolved = await currentPage.next(context);
-            if (resolved) {
-                return resolved;
-            }
-        }
-
-        const currentIndex = this.pages.findIndex(
-            (page) => page.id === currentPage.id,
-        );
-        if (currentIndex >= 0 && currentIndex + 1 < this.pages.length) {
-            return this.pages[currentIndex + 1].id;
-        }
-
-        return undefined;
-    }
-
-    private async ensureDatabaseState(
-        chatId: TelegramBot.ChatId,
-        session: IChatSessionState,
-        message?: TelegramBot.Message,
-        currentPageId?: string,
-    ): Promise<IContextDatabaseState> {
-        if (!this.prisma) {
-            return {};
-        }
-
-        const telegramUser = message?.from ?? session.user;
-        if (!telegramUser) {
-            return {};
-        }
-
-        const telegramId = this.normalizeTelegramId(telegramUser.id);
-        const chatIdentifier = this.normalizeChatId(chatId);
-
-        const user = (await this.prisma.user.upsert({
-            where: { telegramId },
-            update: {
-                chatId: chatIdentifier,
-                username: telegramUser.username ?? undefined,
-                firstName: telegramUser.first_name ?? undefined,
-                lastName: telegramUser.last_name ?? undefined,
-                languageCode: telegramUser.language_code ?? undefined,
-            },
-            create: {
-                telegramId,
-                chatId: chatIdentifier,
-                username: telegramUser.username,
-                firstName: telegramUser.first_name,
-                lastName: telegramUser.last_name,
-                languageCode: telegramUser.language_code,
-            },
-        })) as unknown as IPrismaUser;
-
-        const targetPageId = currentPageId ?? session.pageId;
-
-        let stepState = (await this.prisma.stepState.findUnique({
-            where: {
-                userId_slug: {
-                    userId: user.id,
-                    slug: this.slug,
-                },
-            },
-        })) as unknown as IPrismaStepState | null;
-
-        if (!stepState) {
-            stepState = (await this.prisma.stepState.create({
-                data: {
-                    userId: user.id,
-                    chatId: chatIdentifier,
-                    slug: this.slug,
-                    currentPage: targetPageId ?? null,
-                    answers: this.serializeValue(session.data ?? {}),
-                    history: this.serializeValue([]),
-                },
-            })) as unknown as IPrismaStepState;
-        } else {
-            const updates: Record<string, unknown> = {};
-
-            if (stepState.chatId !== chatIdentifier) {
-                updates.chatId = chatIdentifier;
-            }
-
-            if (
-                targetPageId !== undefined &&
-                stepState.currentPage !== targetPageId
-            ) {
-                updates.currentPage = targetPageId;
-            }
-
-            if (Object.keys(updates).length > 0) {
-                stepState = (await this.prisma.stepState.update({
-                    where: { id: stepState.id },
-                    data: updates,
-                })) as unknown as IPrismaStepState;
-            }
-        }
-
-        return {
-            user,
-            stepState,
-        };
-    }
-
-    private async persistStepProgress(
-        stepState: IPrismaStepState | undefined,
-        pageId: string,
-        value: unknown,
-    ): Promise<IPrismaStepState | undefined> {
-        if (!this.prisma || !stepState) {
-            return stepState;
-        }
-
-        const serializedValue = this.serializeValue(value);
-        const answers = this.normalizeAnswers(stepState.answers);
-        answers[pageId] = serializedValue;
-
-        const history = this.normalizeHistory(stepState.history);
-        history.push({
-            pageId,
-            value: serializedValue,
-            timestamp: new Date().toISOString(),
-        });
-
-        const updatedStepState = (await this.prisma.stepState.update({
-            where: { id: stepState.id },
-            data: {
-                answers,
-                history: JSON.stringify(history),
-            },
-        })) as unknown as IPrismaStepState;
-
-        await this.prisma.formEntry.upsert({
-            where: {
-                stepStateId_pageId: {
-                    stepStateId: updatedStepState.id,
-                    pageId,
-                },
-            },
-            update: {
-                payload: serializedValue,
-            },
-            create: {
-                userId: updatedStepState.userId,
-                stepStateId: updatedStepState.id,
-                slug: updatedStepState.slug,
-                pageId,
-                payload: serializedValue,
-            },
-        });
-
-        return updatedStepState;
-    }
-
-    private async updateStepStateCurrentPage(
-        stepState: IPrismaStepState | undefined,
-        pageId: string | undefined,
-    ): Promise<IPrismaStepState | undefined> {
-        if (!this.prisma || !stepState) {
-            return stepState;
-        }
-
-        const targetPage = pageId ?? null;
-        if (stepState.currentPage === targetPage) {
-            return stepState;
-        }
-
-        return (await this.prisma.stepState.update({
-            where: { id: stepState.id },
-            data: {
-                currentPage: targetPage,
-            },
-        })) as unknown as IPrismaStepState;
-    }
-
-    private normalizeAnswers(
-        answers: unknown,
-    ): Record<string, TPrismaJsonValue | null> {
-        if (!answers || typeof answers !== 'object' || Array.isArray(answers)) {
-            return {};
-        }
-
-        return {
-            ...(answers as Record<string, TPrismaJsonValue | null>),
-        };
-    }
-
-    private normalizeHistory(history: unknown): IStepHistoryEntry[] {
-        if (!Array.isArray(history)) {
-            return [];
-        }
-
-        return history
-            .map((entry) =>
-                typeof entry === 'object' && entry !== null
-                    ? (entry as Record<string, unknown>)
-                    : undefined,
-            )
-            .filter((entry): entry is Record<string, unknown> => Boolean(entry))
-            .map((entry) => {
-                const pageIdValue = entry.pageId;
-                const timestampValue = entry.timestamp;
-
-                const pageId =
-                    typeof pageIdValue === 'string'
-                        ? pageIdValue
-                        : String(pageIdValue ?? '');
-                const timestamp =
-                    typeof timestampValue === 'string'
-                        ? timestampValue
-                        : new Date().toISOString();
-
-                return {
-                    pageId,
-                    timestamp,
-                    value: this.serializeValue(entry.value),
-                };
-            });
-    }
-
-    private serializeValue(value: unknown): TPrismaJsonValue | null {
-        if (value === undefined) {
-            return null;
-        }
-
-        if (
-            value === null ||
-            typeof value === 'string' ||
-            typeof value === 'number' ||
-            typeof value === 'boolean'
-        ) {
-            return value as TPrismaJsonValue;
-        }
-
-        if (typeof value === 'bigint') {
-            return value.toString();
-        }
-
-        if (Array.isArray(value)) {
-            return value.map((item) =>
-                this.serializeValue(item),
-            ) as TPrismaJsonValue;
-        }
-
-        if (typeof value === 'object') {
-            const entries = Object.entries(value as Record<string, unknown>);
-            const normalized: Record<string, TPrismaJsonValue | null> = {};
-            for (const [key, item] of entries) {
-                normalized[key] = this.serializeValue(item);
-            }
-            return normalized as TPrismaJsonValue;
-        }
-
-        return null;
-    }
-
-    private normalizeChatId(chatId: TelegramBot.ChatId): string {
-        return typeof chatId === 'string' ? chatId : chatId.toString();
-    }
-
-    private normalizeTelegramId(id: number | string): bigint {
-        return typeof id === 'string' ? BigInt(id) : BigInt(id);
-    }
-
-    private async renderPage(
-        page: IBotPage,
-        context: IBotBuilderContext,
-    ): Promise<void> {
-        const middlewareResult = await this.executePageMiddlewares(
-            page,
-            context,
-        );
-
-        if (!middlewareResult.allow) {
-            const message =
-                middlewareResult.message ??
-                DEFAULT_PAGE_MIDDLEWARE_REJECTION_MESSAGE;
-
-            this.logger.warn(
-                `Page middlewares prevented rendering of "${page.id}" for chat ${context.chatId}`,
-            );
-
-            await this.bot.sendMessage(context.chatId, message);
-            return;
-        }
-
-        const payload = await this.resolvePageContent(page.content, context);
-        const keyboard = await this.resolveKeyboard(page.id, context);
-
-        const options: TelegramBot.SendMessageOptions = {
-            ...(payload.options ?? {}),
-        };
-
-        if (keyboard && !options.reply_markup) {
-            options.reply_markup = keyboard;
-        }
-
-        await this.bot.sendMessage(context.chatId, payload.text, options);
-    }
-
-    private async executePageMiddlewares(
-        page: IBotPage,
-        context: IBotBuilderContext,
-    ): Promise<IBotPageMiddlewareResult> {
-        const middlewares = this.resolvePageMiddlewares(page);
-        if (middlewares.length === 0) {
-            return { allow: true };
-        }
-
-        for (const middleware of middlewares) {
-            try {
-                const result = await middleware.handler(context, page);
-                const normalized = this.normalizePageMiddlewareResult(result);
-
-                if (!normalized.allow) {
-                    return normalized;
-                }
-            } catch (error) {
-                const message =
-                    error instanceof Error ? error.message : undefined;
-                return { allow: false, message };
-            }
-        }
-
-        return { allow: true };
-    }
-
-    private resolvePageMiddlewares(page: IBotPage): IBotPageMiddlewareConfig[] {
-        if (!page.middlewares || page.middlewares.length === 0) {
-            return [];
-        }
-
-        const resolved: IBotPageMiddlewareConfig[] = [];
-
-        for (const middleware of page.middlewares) {
-            if (typeof middleware === 'string') {
-                const registered = this.pageMiddlewaresMap.get(middleware);
-                if (!registered) {
-                    this.logger.warn(
-                        `Page middleware "${middleware}" not found for page "${page.id}"`,
-                    );
-                    continue;
-                }
-
-                resolved.push(registered);
-                continue;
-            }
-
-            resolved.push(middleware);
-        }
-
-        return resolved.sort((a, b) => (b.priority ?? 0) - (a.priority ?? 0));
-    }
-
-    private normalizePageMiddlewareResult(
-        result: TBotPageMiddlewareHandlerResult,
-    ): IBotPageMiddlewareResult {
-        if (typeof result === 'boolean') {
-            return { allow: result };
-        }
-
-        if (result && typeof result === 'object' && 'allow' in result) {
-            return {
-                allow: Boolean(result.allow),
-                message:
-                    typeof result.message === 'string'
-                        ? result.message
-                        : undefined,
-            };
-        }
-
-        return { allow: true };
-    }
-
-    private async resolvePageContent(
-        content: TBotPageContent,
-        context: IBotBuilderContext,
-    ): Promise<{ text: string; options?: TelegramBot.SendMessageOptions }> {
-        const result = await this.normalizePageContent(content, context);
-
-        if (typeof result === 'string') {
-            return { text: result };
-        }
-
-        return result;
-    }
-
-    private async normalizePageContent(
-        content: TBotPageContent,
-        context: IBotBuilderContext,
-    ): Promise<TBotPageContentResult> {
-        if (typeof content === 'function') {
-            return await content(context);
-        }
-
-        return content;
-    }
-
-    private async resolveKeyboard(
-        pageId: TBotPageIdentifier,
-        context: IBotBuilderContext,
-    ): Promise<TBotKeyboardMarkup | undefined> {
-        const keyboard = this.keyboardsMap.get(pageId);
-        if (keyboard) {
-            const markup = await keyboard.resolve(context);
-            if (markup) {
-                return markup;
-            }
-        }
-
-        for (const persistentKeyboard of this.persistentKeyboards) {
-            const markup = await persistentKeyboard.resolve(context);
-            if (markup) {
-                return markup;
-            }
-        }
-
-        return undefined;
-    }
-
-    private createDefaultSessionStorage(): IBotSessionStorage<IChatSessionState> {
-        const store = new Map<string, IChatSessionState>();
-        return {
-            get: (chatId: TelegramBot.ChatId) => store.get(chatId.toString()),
-            set: (chatId: TelegramBot.ChatId, state: IChatSessionState) => {
-                store.set(chatId.toString(), state);
-            },
-            delete: (chatId: TelegramBot.ChatId) => {
-                store.delete(chatId.toString());
-            },
         };
     }
 }

--- a/src/builder/runtime/page-navigator.ts
+++ b/src/builder/runtime/page-navigator.ts
@@ -1,0 +1,381 @@
+import { ValidationError } from 'yup';
+import TelegramBot = require('node-telegram-bot-api');
+import {
+    IBotBuilderContext,
+    IBotKeyboardConfig,
+    IBotPage,
+    IBotPageMiddlewareConfig,
+    IBotPageMiddlewareResult,
+    TBotKeyboardMarkup,
+    TBotPageIdentifier,
+    TBotPageMiddlewareHandlerResult,
+    TBotPageContent,
+    TBotPageContentResult,
+} from '../../app.interface';
+import { PublisherService } from 'otostogan-nest-logger';
+
+const DEFAULT_PAGE_MIDDLEWARE_REJECTION_MESSAGE =
+    'Access to this page is denied..';
+
+export interface PageNavigatorOptions {
+    bot: TelegramBot;
+    logger: PublisherService;
+    initialPageId?: TBotPageIdentifier;
+    keyboards?: IBotKeyboardConfig[];
+    pageMiddlewares?: IBotPageMiddlewareConfig[];
+}
+
+export interface IValidationResult {
+    valid: boolean;
+    errorMessage?: string;
+}
+
+export class PageNavigator {
+    private readonly pages: IBotPage[] = [];
+    private readonly pagesMap = new Map<TBotPageIdentifier, IBotPage>();
+    private readonly keyboardsMap = new Map<string, IBotKeyboardConfig>();
+    private readonly persistentKeyboards: IBotKeyboardConfig[] = [];
+    private readonly pageMiddlewaresMap = new Map<
+        string,
+        IBotPageMiddlewareConfig
+    >();
+    private initialPageId?: TBotPageIdentifier;
+
+    constructor(private readonly options: PageNavigatorOptions) {
+        this.initialPageId = options.initialPageId;
+
+        const keyboards = options.keyboards ?? [];
+        for (const keyboard of keyboards) {
+            if (keyboard.persistent) {
+                this.persistentKeyboards.push(keyboard);
+            } else {
+                this.keyboardsMap.set(keyboard.id, keyboard);
+            }
+        }
+
+        for (const middleware of options.pageMiddlewares ?? []) {
+            if (
+                middleware.name &&
+                typeof middleware.name === 'string' &&
+                middleware.name.length > 0
+            ) {
+                this.pageMiddlewaresMap.set(middleware.name, middleware);
+            }
+        }
+    }
+
+    public registerPages(pages: IBotPage[]): void {
+        if (!Array.isArray(pages) || pages.length === 0) {
+            return;
+        }
+
+        for (const page of pages) {
+            if (!page || typeof page.id !== 'string' || page.id.length === 0) {
+                this.options.logger.warn(
+                    'Attempted to register a page without a valid identifier',
+                );
+                continue;
+            }
+
+            const existingIndex = this.pages.findIndex(
+                (registeredPage) => registeredPage.id === page.id,
+            );
+
+            if (existingIndex >= 0) {
+                this.pages[existingIndex] = page;
+            } else {
+                this.pages.push(page);
+            }
+
+            this.pagesMap.set(page.id, page);
+        }
+
+        if (!this.initialPageId && this.pages.length > 0) {
+            this.initialPageId = this.pages[0].id;
+        }
+
+        if (this.initialPageId && !this.pagesMap.has(this.initialPageId)) {
+            this.options.logger.warn(
+                `Initial page with id "${this.initialPageId}" not found among registered pages`,
+            );
+        }
+    }
+
+    public resolvePage(pageId: TBotPageIdentifier): IBotPage | undefined {
+        return this.pagesMap.get(pageId);
+    }
+
+    public resolveInitialPage(): IBotPage | undefined {
+        if (this.initialPageId) {
+            const initialPage = this.pagesMap.get(this.initialPageId);
+            if (initialPage) {
+                return initialPage;
+            }
+
+            this.options.logger.warn(
+                `Initial page with id "${this.initialPageId}" not found among registered pages`,
+            );
+        }
+
+        return this.pages[0];
+    }
+
+    public setInitialPage(pageId: TBotPageIdentifier | undefined): void {
+        this.initialPageId = pageId;
+    }
+
+    public extractMessageValue(message: TelegramBot.Message): unknown {
+        if (typeof message.text === 'string') {
+            return message.text;
+        }
+
+        if (typeof message.caption === 'string') {
+            return message.caption;
+        }
+
+        if (message.contact) {
+            return message.contact;
+        }
+
+        if (message.location) {
+            return message.location;
+        }
+
+        if (message.photo) {
+            return message.photo;
+        }
+
+        if (message.document) {
+            return message.document;
+        }
+
+        return message;
+    }
+
+    public async validatePageValue(
+        page: IBotPage,
+        value: unknown,
+        context: IBotBuilderContext,
+    ): Promise<IValidationResult> {
+        if (page.yup) {
+            try {
+                await page.yup.validate(value, { context });
+            } catch (error) {
+                if (error instanceof ValidationError) {
+                    return { valid: false, errorMessage: error.message };
+                }
+
+                return {
+                    valid: false,
+                    errorMessage: 'Ошибка проверки данных, попробуйте ещё раз.',
+                };
+            }
+        }
+
+        if (page.validate) {
+            try {
+                const isValid = await page.validate(value, context);
+                if (!isValid) {
+                    return {
+                        valid: false,
+                        errorMessage:
+                            'Введены некорректные данные, попробуйте ещё раз.',
+                    };
+                }
+            } catch (error) {
+                const message =
+                    error instanceof Error
+                        ? error.message
+                        : 'Ошибка проверки данных, попробуйте ещё раз.';
+                return { valid: false, errorMessage: message };
+            }
+        }
+
+        return { valid: true };
+    }
+
+    public async resolveNextPageId(
+        currentPage: IBotPage,
+        context: IBotBuilderContext,
+    ): Promise<TBotPageIdentifier | undefined> {
+        if (currentPage.next) {
+            const resolved = await currentPage.next(context);
+            if (resolved) {
+                return resolved;
+            }
+        }
+
+        const currentIndex = this.pages.findIndex(
+            (page) => page.id === currentPage.id,
+        );
+        if (currentIndex >= 0 && currentIndex + 1 < this.pages.length) {
+            return this.pages[currentIndex + 1].id;
+        }
+
+        return undefined;
+    }
+
+    public async renderPage(
+        page: IBotPage,
+        context: IBotBuilderContext,
+    ): Promise<void> {
+        const middlewareResult = await this.executePageMiddlewares(
+            page,
+            context,
+        );
+
+        if (!middlewareResult.allow) {
+            const message =
+                middlewareResult.message ??
+                DEFAULT_PAGE_MIDDLEWARE_REJECTION_MESSAGE;
+
+            this.options.logger.warn(
+                `Page middlewares prevented rendering of "${page.id}" for chat ${context.chatId}`,
+            );
+
+            await this.options.bot.sendMessage(context.chatId, message);
+            return;
+        }
+
+        const payload = await this.resolvePageContent(page.content, context);
+        const keyboard = await this.resolveKeyboard(page.id, context);
+
+        const options: TelegramBot.SendMessageOptions = {
+            ...(payload.options ?? {}),
+        };
+
+        if (keyboard) {
+            options.reply_markup = keyboard;
+        }
+
+        await this.options.bot.sendMessage(context.chatId, payload.text, {
+            ...options,
+        });
+    }
+
+    private async executePageMiddlewares(
+        page: IBotPage,
+        context: IBotBuilderContext,
+    ): Promise<IBotPageMiddlewareResult> {
+        const middlewares = this.resolvePageMiddlewares(page);
+        if (middlewares.length === 0) {
+            return { allow: true };
+        }
+
+        for (const middleware of middlewares) {
+            try {
+                const result = await middleware.handler(context, page);
+                const normalized = this.normalizePageMiddlewareResult(result);
+
+                if (!normalized.allow) {
+                    return normalized;
+                }
+            } catch (error) {
+                const message =
+                    error instanceof Error ? error.message : undefined;
+                return { allow: false, message };
+            }
+        }
+
+        return { allow: true };
+    }
+
+    private resolvePageMiddlewares(page: IBotPage): IBotPageMiddlewareConfig[] {
+        if (!page.middlewares || page.middlewares.length === 0) {
+            return [];
+        }
+
+        const resolved: IBotPageMiddlewareConfig[] = [];
+
+        for (const middleware of page.middlewares) {
+            if (typeof middleware === 'string') {
+                const registered = this.pageMiddlewaresMap.get(middleware);
+                if (!registered) {
+                    this.options.logger.warn(
+                        `Page middleware "${middleware}" not found for page "${page.id}"`,
+                    );
+                    continue;
+                }
+
+                resolved.push(registered);
+                continue;
+            }
+
+            resolved.push(middleware);
+        }
+
+        return resolved.sort((a, b) => (b.priority ?? 0) - (a.priority ?? 0));
+    }
+
+    private normalizePageMiddlewareResult(
+        result: TBotPageMiddlewareHandlerResult,
+    ): IBotPageMiddlewareResult {
+        if (typeof result === 'boolean') {
+            return { allow: result };
+        }
+
+        if (result && typeof result === 'object' && 'allow' in result) {
+            return {
+                allow: Boolean(result.allow),
+                message:
+                    typeof result.message === 'string'
+                        ? result.message
+                        : undefined,
+            };
+        }
+
+        return { allow: true };
+    }
+
+    private async resolvePageContent(
+        content: TBotPageContent,
+        context: IBotBuilderContext,
+    ): Promise<{ text: string; options?: TelegramBot.SendMessageOptions }> {
+        const result = await this.normalizePageContent(content, context);
+
+        if (typeof result === 'string') {
+            return { text: result };
+        }
+
+        return result;
+    }
+
+    private async normalizePageContent(
+        content: TBotPageContent,
+        context: IBotBuilderContext,
+    ): Promise<TBotPageContentResult> {
+        if (typeof content === 'function') {
+            return await content(context);
+        }
+
+        return content;
+    }
+
+    private async resolveKeyboard(
+        pageId: TBotPageIdentifier,
+        context: IBotBuilderContext,
+    ): Promise<TBotKeyboardMarkup | undefined> {
+        const keyboard = this.keyboardsMap.get(pageId);
+        if (keyboard) {
+            const markup = await keyboard.resolve(context);
+            if (markup) {
+                return markup;
+            }
+        }
+
+        for (const persistentKeyboard of this.persistentKeyboards) {
+            const markup = await persistentKeyboard.resolve(context);
+            if (markup) {
+                return markup;
+            }
+        }
+
+        return undefined;
+    }
+}
+
+export interface PageNavigatorFactoryOptions extends PageNavigatorOptions {}
+
+export const createPageNavigator = (
+    options: PageNavigatorFactoryOptions,
+): PageNavigator => new PageNavigator(options);

--- a/src/builder/runtime/persistence-gateway.ts
+++ b/src/builder/runtime/persistence-gateway.ts
@@ -1,0 +1,289 @@
+import TelegramBot = require('node-telegram-bot-api');
+import type { PrismaClient } from '@prisma/client/extension';
+import {
+    IPrismaStepState,
+    IPrismaUser,
+    TPrismaJsonValue,
+} from '../../app.interface';
+import { IChatSessionState } from './session-manager';
+
+interface IStepHistoryEntry {
+    pageId: string;
+    value: TPrismaJsonValue | null;
+    timestamp: string;
+}
+
+export interface IContextDatabaseState {
+    user?: IPrismaUser;
+    stepState?: IPrismaStepState;
+}
+
+export interface PersistenceGatewayOptions {
+    prisma?: PrismaClient;
+    slug: string;
+}
+
+export class PersistenceGateway {
+    constructor(private readonly options: PersistenceGatewayOptions) {}
+
+    public get prisma(): PrismaClient | undefined {
+        return this.options.prisma;
+    }
+
+    public async ensureDatabaseState(
+        chatId: TelegramBot.ChatId,
+        session: IChatSessionState,
+        message?: TelegramBot.Message,
+        currentPageId?: string,
+    ): Promise<IContextDatabaseState> {
+        const prisma = this.options.prisma;
+        if (!prisma) {
+            return {};
+        }
+
+        const telegramUser = message?.from ?? session.user;
+        if (!telegramUser) {
+            return {};
+        }
+
+        const telegramId = this.normalizeTelegramId(telegramUser.id);
+        const chatIdentifier = this.normalizeChatId(chatId);
+
+        const user = (await prisma.user.upsert({
+            where: { telegramId },
+            update: {
+                chatId: chatIdentifier,
+                username: telegramUser.username ?? undefined,
+                firstName: telegramUser.first_name ?? undefined,
+                lastName: telegramUser.last_name ?? undefined,
+                languageCode: telegramUser.language_code ?? undefined,
+            },
+            create: {
+                telegramId,
+                chatId: chatIdentifier,
+                username: telegramUser.username,
+                firstName: telegramUser.first_name,
+                lastName: telegramUser.last_name,
+                languageCode: telegramUser.language_code,
+            },
+        })) as unknown as IPrismaUser;
+
+        const targetPageId = currentPageId ?? session.pageId;
+
+        let stepState = (await prisma.stepState.findUnique({
+            where: {
+                userId_slug: {
+                    userId: user.id,
+                    slug: this.options.slug,
+                },
+            },
+        })) as unknown as IPrismaStepState | null;
+
+        if (!stepState) {
+            stepState = (await prisma.stepState.create({
+                data: {
+                    userId: user.id,
+                    chatId: chatIdentifier,
+                    slug: this.options.slug,
+                    currentPage: targetPageId ?? null,
+                    answers: this.serializeValue(session.data ?? {}),
+                    history: this.serializeValue([]),
+                },
+            })) as unknown as IPrismaStepState;
+        } else {
+            const updates: Record<string, unknown> = {};
+
+            if (stepState.chatId !== chatIdentifier) {
+                updates.chatId = chatIdentifier;
+            }
+
+            if (
+                targetPageId !== undefined &&
+                stepState.currentPage !== targetPageId
+            ) {
+                updates.currentPage = targetPageId;
+            }
+
+            if (Object.keys(updates).length > 0) {
+                stepState = (await prisma.stepState.update({
+                    where: { id: stepState.id },
+                    data: updates,
+                })) as unknown as IPrismaStepState;
+            }
+        }
+
+        return {
+            user,
+            stepState,
+        };
+    }
+
+    public async persistStepProgress(
+        stepState: IPrismaStepState | undefined,
+        pageId: string,
+        value: unknown,
+    ): Promise<IPrismaStepState | undefined> {
+        const prisma = this.options.prisma;
+        if (!prisma || !stepState) {
+            return stepState;
+        }
+
+        const serializedValue = this.serializeValue(value);
+        const answers = this.normalizeAnswers(stepState.answers);
+        answers[pageId] = serializedValue;
+
+        const history = this.normalizeHistory(stepState.history);
+        history.push({
+            pageId,
+            value: serializedValue,
+            timestamp: new Date().toISOString(),
+        });
+
+        const updatedStepState = (await prisma.stepState.update({
+            where: { id: stepState.id },
+            data: {
+                answers,
+                history: JSON.stringify(history),
+            },
+        })) as unknown as IPrismaStepState;
+
+        await prisma.formEntry.upsert({
+            where: {
+                stepStateId_pageId: {
+                    stepStateId: updatedStepState.id,
+                    pageId,
+                },
+            },
+            update: {
+                payload: serializedValue,
+            },
+            create: {
+                userId: updatedStepState.userId,
+                stepStateId: updatedStepState.id,
+                slug: updatedStepState.slug,
+                pageId,
+                payload: serializedValue,
+            },
+        });
+
+        return updatedStepState;
+    }
+
+    public async updateStepStateCurrentPage(
+        stepState: IPrismaStepState | undefined,
+        pageId: string | undefined,
+    ): Promise<IPrismaStepState | undefined> {
+        const prisma = this.options.prisma;
+        if (!prisma || !stepState) {
+            return stepState;
+        }
+
+        const targetPage = pageId ?? null;
+        if (stepState.currentPage === targetPage) {
+            return stepState;
+        }
+
+        return (await prisma.stepState.update({
+            where: { id: stepState.id },
+            data: {
+                currentPage: targetPage,
+            },
+        })) as unknown as IPrismaStepState;
+    }
+
+    private normalizeAnswers(
+        answers: unknown,
+    ): Record<string, TPrismaJsonValue | null> {
+        if (!answers || typeof answers !== 'object' || Array.isArray(answers)) {
+            return {};
+        }
+
+        return {
+            ...(answers as Record<string, TPrismaJsonValue | null>),
+        };
+    }
+
+    private normalizeHistory(history: unknown): IStepHistoryEntry[] {
+        if (!Array.isArray(history)) {
+            return [];
+        }
+
+        return history
+            .map((entry) =>
+                typeof entry === 'object' && entry !== null
+                    ? (entry as Record<string, unknown>)
+                    : undefined,
+            )
+            .filter((entry): entry is Record<string, unknown> => Boolean(entry))
+            .map((entry) => {
+                const pageIdValue = entry.pageId;
+                const timestampValue = entry.timestamp;
+
+                const pageId =
+                    typeof pageIdValue === 'string'
+                        ? pageIdValue
+                        : String(pageIdValue ?? '');
+                const timestamp =
+                    typeof timestampValue === 'string'
+                        ? timestampValue
+                        : new Date().toISOString();
+
+                return {
+                    pageId,
+                    timestamp,
+                    value: this.serializeValue(entry.value),
+                };
+            });
+    }
+
+    private serializeValue(value: unknown): TPrismaJsonValue | null {
+        if (value === undefined) {
+            return null;
+        }
+
+        if (
+            value === null ||
+            typeof value === 'string' ||
+            typeof value === 'number' ||
+            typeof value === 'boolean'
+        ) {
+            return value as TPrismaJsonValue;
+        }
+
+        if (typeof value === 'bigint') {
+            return value.toString();
+        }
+
+        if (Array.isArray(value)) {
+            return value.map((item) =>
+                this.serializeValue(item),
+            ) as TPrismaJsonValue;
+        }
+
+        if (typeof value === 'object') {
+            const entries = Object.entries(value as Record<string, unknown>);
+            const normalized: Record<string, TPrismaJsonValue | null> = {};
+            for (const [key, item] of entries) {
+                normalized[key] = this.serializeValue(item);
+            }
+            return normalized as TPrismaJsonValue;
+        }
+
+        return null;
+    }
+
+    private normalizeChatId(chatId: TelegramBot.ChatId): string {
+        return typeof chatId === 'string' ? chatId : chatId.toString();
+    }
+
+    private normalizeTelegramId(id: number | string): bigint {
+        return typeof id === 'string' ? BigInt(id) : BigInt(id);
+    }
+}
+
+export interface PersistenceGatewayFactoryOptions
+    extends PersistenceGatewayOptions {}
+
+export const createPersistenceGateway = (
+    options: PersistenceGatewayFactoryOptions,
+): PersistenceGateway => new PersistenceGateway(options);

--- a/src/builder/runtime/session-manager.ts
+++ b/src/builder/runtime/session-manager.ts
@@ -1,0 +1,124 @@
+import TelegramBot = require('node-telegram-bot-api');
+import {
+    IBotSessionState,
+    IBotSessionStorage,
+    TBotPageIdentifier,
+} from '../../app.interface';
+
+export interface IChatSessionState {
+    pageId?: TBotPageIdentifier;
+    data: IBotSessionState;
+    user?: TelegramBot.User;
+}
+
+export interface SessionManagerOptions {
+    sessionStorage?: IBotSessionStorage<IChatSessionState | IBotSessionState>;
+}
+
+export class SessionManager {
+    private readonly sessionStorage: IBotSessionStorage<
+        IChatSessionState | IBotSessionState
+    >;
+
+    private readonly sessionCache = new Map<string, IChatSessionState>();
+
+    constructor(options: SessionManagerOptions = {}) {
+        this.sessionStorage =
+            options.sessionStorage ??
+            (this.createDefaultSessionStorage() as IBotSessionStorage<
+                IChatSessionState | IBotSessionState
+            >);
+    }
+
+    public async getSession(
+        chatId: TelegramBot.ChatId,
+    ): Promise<IChatSessionState> {
+        const key = chatId.toString();
+        const cached = this.sessionCache.get(key);
+        if (cached) {
+            return cached;
+        }
+
+        const stored = await this.sessionStorage.get(chatId);
+        const session = this.normalizeSessionState(stored) ?? {
+            pageId: undefined,
+            data: {},
+        };
+
+        this.sessionCache.set(key, session);
+        return session;
+    }
+
+    public async saveSession(
+        chatId: TelegramBot.ChatId,
+        session: IChatSessionState,
+    ): Promise<void> {
+        const key = chatId.toString();
+        this.sessionCache.set(key, session);
+        await this.sessionStorage.set(chatId, session);
+    }
+
+    public async deleteSession(chatId: TelegramBot.ChatId): Promise<void> {
+        const key = chatId.toString();
+        this.sessionCache.delete(key);
+        if (this.sessionStorage.delete) {
+            await this.sessionStorage.delete(chatId);
+        }
+    }
+
+    private normalizeSessionState(
+        stored?: IChatSessionState | IBotSessionState | null,
+    ): IChatSessionState | undefined {
+        if (!stored) {
+            return undefined;
+        }
+
+        if (this.isChatSessionState(stored)) {
+            stored.data = stored.data ?? {};
+            return stored;
+        }
+
+        if (this.isSessionState(stored)) {
+            return {
+                pageId: undefined,
+                data: stored,
+            };
+        }
+
+        return undefined;
+    }
+
+    private isChatSessionState(value: unknown): value is IChatSessionState {
+        return (
+            typeof value === 'object' &&
+            value !== null &&
+            'data' in value &&
+            !Array.isArray((value as { data?: unknown }).data)
+        );
+    }
+
+    private isSessionState(value: unknown): value is IBotSessionState {
+        return (
+            typeof value === 'object' && value !== null && !Array.isArray(value)
+        );
+    }
+
+    private createDefaultSessionStorage(): IBotSessionStorage<IChatSessionState> {
+        const store = new Map<string, IChatSessionState>();
+        return {
+            get: (chatId: TelegramBot.ChatId) => store.get(chatId.toString()),
+            set: (chatId: TelegramBot.ChatId, state: IChatSessionState) => {
+                store.set(chatId.toString(), state);
+            },
+            delete: (chatId: TelegramBot.ChatId) => {
+                store.delete(chatId.toString());
+            },
+        };
+    }
+}
+
+export interface SessionManagerFactoryOptions extends SessionManagerOptions {}
+
+export const createSessionManager = (
+    options: SessionManagerFactoryOptions = {},
+): SessionManager => new SessionManager(options);

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,8 +3,27 @@ export { BuilderService } from './builder/builder.service';
 export {
     BotRuntime,
     IBotRuntimeOptions,
+    BotRuntimeDependencies,
     normalizeBotOptions,
 } from './builder/bot-runtime';
+export {
+    PageNavigator,
+    PageNavigatorFactoryOptions,
+    IValidationResult,
+    createPageNavigator,
+} from './builder/runtime/page-navigator';
+export {
+    SessionManager,
+    SessionManagerFactoryOptions,
+    IChatSessionState,
+    createSessionManager,
+} from './builder/runtime/session-manager';
+export {
+    PersistenceGateway,
+    PersistenceGatewayFactoryOptions,
+    IContextDatabaseState,
+    createPersistenceGateway,
+} from './builder/runtime/persistence-gateway';
 export {
     BOT_BUILDER_MODULE_OPTIONS,
     BOT_BUILDER_PRISMA,


### PR DESCRIPTION
## Summary
- extract page navigation, session management and persistence logic into dedicated runtime services
- update BotRuntime to depend on injected factories and delegate to the new services
- export the new runtime components via the package index and document their customization in the README

## Testing
- npm run build *(fails: src/main.ts references missing ./dev/dev.module)*

------
https://chatgpt.com/codex/tasks/task_e_68ceb605c7b88328a76432fe96c34558