### PR TITLE
Add middleware pipeline support and handler registration

### DIFF
--- a/src/builder/bot-runtime.ts
+++ b/src/builder/bot-runtime.ts
@@ -3,6 +3,9 @@ import {
     IBotBuilderOptions,
     IBotPage,
     IBotPageNavigationOptions,
+    IBotHandler,
+    IBotMiddlewareConfig,
+    IBotMiddlewareContext,
     IBotSessionState,
     IBotSessionStorage,
     TBotPageIdentifier,
@@ -27,6 +30,11 @@ import {
 import { createPageNavigator } from './runtime/page-navigator';
 import { createSessionManager } from './runtime/session-manager';
 import { createPersistenceGateway } from './runtime/persistence-gateway';
+import {
+    buildMiddlewarePipeline,
+    mergeMiddlewareConfigs,
+    sortMiddlewareConfigs,
+} from './runtime/middleware-pipeline';
 
 export interface IBotRuntimeOptions extends IBotBuilderOptions {
     id: string;
@@ -106,6 +114,7 @@ export class BotRuntime {
     private readonly sessionManager: SessionManager;
     private readonly persistenceGateway: PersistenceGateway;
     private readonly helperServices: Record<string, unknown>;
+    private readonly globalMiddlewares: IBotMiddlewareConfig[];
 
     constructor(
         options: IBotRuntimeOptions,
@@ -119,6 +128,9 @@ export class BotRuntime {
         this.logger = logger;
 
         this.helperServices = options.services ?? {};
+        this.globalMiddlewares = sortMiddlewareConfigs(
+            options.middlewares ?? [],
+        );
 
         const providedSessionStorage = options.sessionStorage as
             | IBotSessionStorage<IChatSessionState | IBotSessionState>
@@ -152,7 +164,7 @@ export class BotRuntime {
 
         this.logger.info(`BotBuilder runtime "${this.id}" initialized`);
 
-        this.registerHandlers();
+        this.registerHandlers(options.handlers ?? []);
     }
 
     public registerPages(pages: IBotPage[]): void {
@@ -205,8 +217,53 @@ export class BotRuntime {
         await this.pageNavigator.renderPage(page, buildContext());
     }
 
-    private registerHandlers(): void {
+    private registerHandlers(handlers: IBotHandler[] = []): void {
         this.bot.on('message', this.handleMessage);
+
+        if (!Array.isArray(handlers) || handlers.length === 0) {
+            return;
+        }
+
+        for (const handler of handlers) {
+            if (!handler || typeof handler.event !== 'string') {
+                this.logger.warn('Attempted to register an invalid handler');
+                continue;
+            }
+
+            if (typeof handler.listener !== 'function') {
+                this.logger.warn(
+                    `Handler for event "${handler.event}" does not provide a listener`,
+                );
+                continue;
+            }
+
+            const handlerMiddlewares = sortMiddlewareConfigs(
+                handler.middlewares ?? [],
+            );
+            const combinedMiddlewares = mergeMiddlewareConfigs(
+                this.globalMiddlewares,
+                handlerMiddlewares,
+            );
+
+            const pipeline = buildMiddlewarePipeline<
+                Parameters<typeof handler.listener>
+            >({
+                event: handler.event,
+                middlewares: combinedMiddlewares,
+                handler: async (...args) => {
+                    await Promise.resolve(handler.listener(...args));
+                },
+                contextFactory: (event, args) =>
+                    this.buildMiddlewareContext(event, args as unknown[]),
+                onError: (error) =>
+                    this.logMiddlewareError(handler.event, error),
+            });
+
+            this.bot.on(
+                handler.event,
+                pipeline as TelegramBot.TelegramEvents[typeof handler.event],
+            );
+        }
     }
 
     private readonly handleMessage = async (
@@ -302,6 +359,215 @@ export class BotRuntime {
             this.logger.error(message);
         }
     };
+
+    private async buildMiddlewareContext(
+        event: keyof TelegramBot.TelegramEvents,
+        args: unknown[],
+    ): Promise<IBotMiddlewareContext> {
+        const message = this.extractMessageFromArgs(args);
+        const metadata = this.extractMetadataFromArgs(args, message);
+        const user = this.resolveUserFromArgs(args, message);
+        const chatId = this.resolveChatIdFromArgs(args, message, user);
+
+        if (chatId !== undefined) {
+            const session = await this.sessionManager.getSession(chatId);
+            if (user) {
+                session.user = user;
+            }
+
+            const { database, buildContext } = await this.prepareContext({
+                chatId,
+                session,
+                message,
+                metadata,
+                user,
+            });
+
+            const context = buildContext({ message, metadata, user });
+
+            return {
+                ...context,
+                db: database,
+                event,
+                args,
+            };
+        }
+
+        return {
+            botId: this.id,
+            bot: this.bot,
+            chatId: 'unknown' as TelegramBot.ChatId,
+            message,
+            metadata,
+            session: undefined,
+            user,
+            prisma: this.persistenceGateway.prisma,
+            db: undefined,
+            services: this.helperServices,
+            event,
+            args,
+        };
+    }
+
+    private logMiddlewareError(
+        event: keyof TelegramBot.TelegramEvents,
+        error: unknown,
+    ): void {
+        const eventName = String(event);
+        const message =
+            error instanceof Error
+                ? `Error in middleware pipeline for event "${eventName}": ${error.message}`
+                : `Error in middleware pipeline for event "${eventName}"`;
+        this.logger.error(message);
+    }
+
+    private extractMessageFromArgs(
+        args: unknown[],
+    ): TelegramBot.Message | undefined {
+        for (const arg of args) {
+            const message = this.findMessageInValue(arg);
+            if (message) {
+                return message;
+            }
+        }
+
+        return undefined;
+    }
+
+    private findMessageInValue(
+        value: unknown,
+        visited = new Set<unknown>(),
+    ): TelegramBot.Message | undefined {
+        if (!value || typeof value !== 'object') {
+            return undefined;
+        }
+
+        if (visited.has(value)) {
+            return undefined;
+        }
+        visited.add(value);
+
+        const record = value as Record<string, unknown>;
+
+        if ('message_id' in record && 'chat' in record) {
+            return value as TelegramBot.Message;
+        }
+
+        if ('message' in record) {
+            return this.findMessageInValue(record.message, visited);
+        }
+
+        return undefined;
+    }
+
+    private extractMetadataFromArgs(
+        args: unknown[],
+        message?: TelegramBot.Message,
+    ): TelegramBot.Metadata | undefined {
+        if (args.length < 2) {
+            return undefined;
+        }
+
+        const candidate = args[1];
+        if (!candidate || typeof candidate !== 'object' || candidate === message) {
+            return undefined;
+        }
+
+        return candidate as TelegramBot.Metadata;
+    }
+
+    private resolveChatIdFromArgs(
+        args: unknown[],
+        message?: TelegramBot.Message,
+        user?: TelegramBot.User,
+    ): TelegramBot.ChatId | undefined {
+        if (message?.chat?.id !== undefined) {
+            return message.chat.id;
+        }
+
+        for (const arg of args) {
+            const chatId = this.extractChatIdFromValue(arg);
+            if (chatId !== undefined) {
+                return chatId;
+            }
+        }
+
+        if (user?.id !== undefined) {
+            return user.id;
+        }
+
+        return undefined;
+    }
+
+    private extractChatIdFromValue(value: unknown): TelegramBot.ChatId | undefined {
+        if (!value || typeof value !== 'object') {
+            return undefined;
+        }
+
+        const record = value as Record<string, unknown>;
+
+        if ('chat' in record) {
+            const chat = record.chat as { id?: TelegramBot.ChatId } | undefined;
+            if (chat && chat.id !== undefined) {
+                return chat.id;
+            }
+        }
+
+        if ('message' in record) {
+            const nested = this.extractChatIdFromValue(record.message);
+            if (nested !== undefined) {
+                return nested;
+            }
+        }
+
+        if ('from' in record) {
+            const from = record.from as { id?: TelegramBot.ChatId } | undefined;
+            if (from && from.id !== undefined) {
+                return from.id;
+            }
+        }
+
+        return undefined;
+    }
+
+    private resolveUserFromArgs(
+        args: unknown[],
+        message?: TelegramBot.Message,
+    ): TelegramBot.User | undefined {
+        if (message?.from) {
+            return message.from;
+        }
+
+        for (const arg of args) {
+            const user = this.extractUserFromValue(arg);
+            if (user) {
+                return user;
+            }
+        }
+
+        return undefined;
+    }
+
+    private extractUserFromValue(value: unknown): TelegramBot.User | undefined {
+        if (!value || typeof value !== 'object') {
+            return undefined;
+        }
+
+        const record = value as Record<string, unknown>;
+
+        if ('from' in record) {
+            const from = record.from as TelegramBot.User | undefined;
+            if (from) {
+                return from;
+            }
+        }
+
+        if ('message' in record) {
+            return this.extractUserFromValue(record.message);
+        }
+
+        return undefined;
+    }
 
     private async startFromInitialPage(options: {
         chatId: TelegramBot.ChatId;

--- a/src/builder/runtime/middleware-pipeline.ts
+++ b/src/builder/runtime/middleware-pipeline.ts
@@ -1,0 +1,110 @@
+import { IBotMiddlewareConfig, IBotMiddlewareContext } from '../../app.interface';
+
+export interface BuildMiddlewarePipelineOptions<TArgs extends unknown[]> {
+    event: IBotMiddlewareContext['event'];
+    handler: (...args: TArgs) => void | Promise<void>;
+    middlewares?: IBotMiddlewareConfig[];
+    contextFactory: (
+        event: IBotMiddlewareContext['event'],
+        args: TArgs,
+    ) => IBotMiddlewareContext | Promise<IBotMiddlewareContext>;
+    onError?: (error: unknown) => void;
+}
+
+export const sortMiddlewareConfigs = <T extends { priority?: number }>(
+    middlewares: T[] = [],
+): T[] => [...middlewares].sort((a, b) => (b.priority ?? 0) - (a.priority ?? 0));
+
+export const mergeMiddlewareConfigs = (
+    globalMiddlewares: IBotMiddlewareConfig[] = [],
+    handlerMiddlewares: IBotMiddlewareConfig[] = [],
+): IBotMiddlewareConfig[] => {
+    if (globalMiddlewares.length === 0) {
+        return [...handlerMiddlewares];
+    }
+
+    if (handlerMiddlewares.length === 0) {
+        return [...globalMiddlewares];
+    }
+
+    const result: IBotMiddlewareConfig[] = [];
+    let globalIndex = 0;
+    let handlerIndex = 0;
+
+    while (
+        globalIndex < globalMiddlewares.length ||
+        handlerIndex < handlerMiddlewares.length
+    ) {
+        const global = globalMiddlewares[globalIndex];
+        const handler = handlerMiddlewares[handlerIndex];
+
+        if (handler === undefined) {
+            if (global !== undefined) {
+                result.push(global);
+                globalIndex += 1;
+            }
+            continue;
+        }
+
+        if (global === undefined) {
+            result.push(handler);
+            handlerIndex += 1;
+            continue;
+        }
+
+        if ((global.priority ?? 0) >= (handler.priority ?? 0)) {
+            result.push(global);
+            globalIndex += 1;
+        } else {
+            result.push(handler);
+            handlerIndex += 1;
+        }
+    }
+
+    return result;
+};
+
+export const buildMiddlewarePipeline = <TArgs extends unknown[]>(
+    options: BuildMiddlewarePipelineOptions<TArgs>,
+) => {
+    const sorted = sortMiddlewareConfigs(options.middlewares);
+
+    return async (...args: TArgs): Promise<void> => {
+        const context = await options.contextFactory(options.event, args);
+
+        const execute = async (index: number): Promise<void> => {
+            if (index >= sorted.length) {
+                await options.handler(...args);
+                return;
+            }
+
+            const current = sorted[index];
+            if (!current) {
+                await execute(index + 1);
+                return;
+            }
+
+            let called = false;
+
+            const next = async () => {
+                if (called) {
+                    return;
+                }
+                called = true;
+                await execute(index + 1);
+            };
+
+            await current.handler(context, next);
+        };
+
+        try {
+            await execute(0);
+        } catch (error) {
+            if (options.onError) {
+                options.onError(error);
+            }
+
+            throw error;
+        }
+    };
+};

--- a/src/builder/runtime/page-navigator.ts
+++ b/src/builder/runtime/page-navigator.ts
@@ -39,6 +39,10 @@ export class PageNavigator {
         string,
         IBotPageMiddlewareConfig
     >();
+    private readonly pageMiddlewaresCache = new Map<
+        string,
+        IBotPageMiddlewareConfig[]
+    >();
     private initialPageId?: TBotPageIdentifier;
 
     constructor(private readonly options: PageNavigatorOptions) {
@@ -88,6 +92,7 @@ export class PageNavigator {
             }
 
             this.pagesMap.set(page.id, page);
+            this.cachePageMiddlewares(page);
         }
 
         if (!this.initialPageId && this.pages.length > 0) {
@@ -281,8 +286,13 @@ export class PageNavigator {
     }
 
     private resolvePageMiddlewares(page: IBotPage): IBotPageMiddlewareConfig[] {
+        return this.pageMiddlewaresCache.get(page.id) ?? [];
+    }
+
+    private cachePageMiddlewares(page: IBotPage): void {
         if (!page.middlewares || page.middlewares.length === 0) {
-            return [];
+            this.pageMiddlewaresCache.delete(page.id);
+            return;
         }
 
         const resolved: IBotPageMiddlewareConfig[] = [];
@@ -304,7 +314,8 @@ export class PageNavigator {
             resolved.push(middleware);
         }
 
-        return resolved.sort((a, b) => (b.priority ?? 0) - (a.priority ?? 0));
+        resolved.sort((a, b) => (b.priority ?? 0) - (a.priority ?? 0));
+        this.pageMiddlewaresCache.set(page.id, resolved);
     }
 
     private normalizePageMiddlewareResult(

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,11 @@ export {
     createPageNavigator,
 } from './builder/runtime/page-navigator';
 export {
+    buildMiddlewarePipeline,
+    mergeMiddlewareConfigs,
+    sortMiddlewareConfigs,
+} from './builder/runtime/middleware-pipeline';
+export {
     SessionManager,
     SessionManagerFactoryOptions,
     IChatSessionState,


### PR DESCRIPTION
## Summary
- wire BotRuntime to build middleware-aware handler pipelines from configured middlewares
- cache resolved page middlewares to avoid repeated sorting during rendering
- export reusable middleware pipeline helpers for external integrations

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cebb7dbf6483288d80983e98be9586