### PR TITLE
refactor: introduce persistence gateway contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ await builderService.goToPage('secondary', chatId, 'start');
 
 - `SessionManager` controls session retrieval and persistence.
 - `PageNavigator` resolves pages, keyboards and middleware execution.
-- `PersistenceGateway` encapsulates Prisma synchronization.
+- `PrismaPersistenceGateway` encapsulates Prisma synchronization through the `IPersistenceGateway` contract.
 
 All three services and their factory helpers are exported from the package for advanced scenarios:
 

--- a/src/builder/bot-runtime.ts
+++ b/src/builder/bot-runtime.ts
@@ -24,7 +24,7 @@ import {
 } from './runtime/session-manager';
 import {
     IContextDatabaseState,
-    PersistenceGateway,
+    IPersistenceGateway,
     PersistenceGatewayFactoryOptions,
 } from './runtime/persistence-gateway';
 import { createPageNavigator } from './runtime/page-navigator';
@@ -49,7 +49,7 @@ export interface BotRuntimeDependencies {
     ) => SessionManager;
     persistenceGatewayFactory?: (
         options: PersistenceGatewayFactoryOptions,
-    ) => PersistenceGateway;
+    ) => IPersistenceGateway;
 }
 
 export function normalizeBotOptions(
@@ -114,7 +114,7 @@ export class BotRuntime {
     private readonly logger: PublisherService;
     private readonly pageNavigator: PageNavigator;
     private readonly sessionManager: SessionManager;
-    private readonly persistenceGateway: PersistenceGateway;
+    private readonly persistenceGateway: IPersistenceGateway;
     private readonly helperServices: Record<string, unknown>;
     private readonly globalMiddlewares: IBotMiddlewareConfig[];
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,7 +24,9 @@ export {
     createSessionManager,
 } from './builder/runtime/session-manager';
 export {
-    PersistenceGateway,
+    PrismaPersistenceGateway,
+    PrismaPersistenceGatewayOptions,
+    IPersistenceGateway,
     PersistenceGatewayFactoryOptions,
     IContextDatabaseState,
     createPersistenceGateway,


### PR DESCRIPTION
## Summary
- add the IPersistenceGateway contract with Prisma and no-op implementations
- refactor BotRuntime to resolve the persistence gateway through the new interface
- export the new gateway utilities and refresh runtime documentation

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cebe3edea88328ad973004534a3b4e