### PR TITLE
feat: centralize bot runtime messages

### DIFF
--- a/src/app.interface.ts
+++ b/src/app.interface.ts
@@ -179,6 +179,30 @@ export interface IBotSessionStorage<TState = IBotSessionState> {
     delete?(chatId: TelegramBot.ChatId): Promise<void> | void;
 }
 
+export interface IBotRuntimeMessages {
+    runtimeInitialized(context: { id: string }): string;
+    botIdResolutionFailed(): string;
+    invalidHandler(): string;
+    handlerMissingListener(context: { event: string }): string;
+    pageNotFound(context: {
+        pageId: TBotPageIdentifier;
+        chatId: TelegramBot.ChatId;
+    }): string;
+    nextPageNotFound(context: {
+        pageId: TBotPageIdentifier;
+        chatId: TelegramBot.ChatId;
+    }): string;
+    messageHandlingError(context: { error?: unknown }): string;
+    middlewareError(context: {
+        event: keyof TelegramBot.TelegramEvents;
+        error?: unknown;
+    }): string;
+    noInitialPage(): string;
+    validationFailed(): string;
+}
+
+export type TBotRuntimeMessageOverrides = Partial<IBotRuntimeMessages>;
+
 export interface IBotBuilderOptions {
     TG_BOT_TOKEN: string;
     id?: string;
@@ -192,6 +216,11 @@ export interface IBotBuilderOptions {
     slug?: string;
     services?: Record<string, unknown>;
     pageMiddlewares?: IBotPageMiddlewareConfig[];
+    /**
+     * Override runtime messages to introduce custom localisation or phrasing for
+     * built-in validation and middleware feedback.
+     */
+    messages?: TBotRuntimeMessageOverrides;
 }
 
 export interface IBotBuilderModuleAsyncOptions

--- a/src/builder/builder.messages.ts
+++ b/src/builder/builder.messages.ts
@@ -1,0 +1,49 @@
+import type {
+    IBotRuntimeMessages,
+    TBotRuntimeMessageOverrides,
+} from '../app.interface';
+
+const DEFAULT_MESSAGES: IBotRuntimeMessages = {
+    runtimeInitialized: ({ id }) => `BotBuilder runtime "${id}" initialized`,
+    botIdResolutionFailed: () => 'Bot identifier could not be resolved',
+    invalidHandler: () => 'Attempted to register an invalid handler',
+    handlerMissingListener: ({ event }) =>
+        `Handler for event "${event}" does not provide a listener`,
+    pageNotFound: ({ pageId, chatId }) =>
+        `Page with id "${String(pageId)}" not found for chat ${String(chatId)}`,
+    nextPageNotFound: ({ pageId, chatId }) =>
+        `Next page with id "${String(pageId)}" not found for chat ${String(chatId)}`,
+    messageHandlingError: ({ error }) =>
+        error instanceof Error
+            ? `Error during message handling: ${error.message}`
+            : 'Error during message handling',
+    middlewareError: ({ event, error }) => {
+        const eventName = String(event);
+        if (error instanceof Error) {
+            return `Error in middleware pipeline for event "${eventName}": ${error.message}`;
+        }
+        return `Error in middleware pipeline for event "${eventName}"`;
+    },
+    noInitialPage: () => 'No initial page configured',
+    validationFailed: () => 'Введены некорректные данные, попробуйте ещё раз.',
+};
+
+export const DEFAULT_BOT_RUNTIME_MESSAGES: IBotRuntimeMessages =
+    Object.freeze(DEFAULT_MESSAGES) as IBotRuntimeMessages;
+
+export type BotRuntimeMessageFactory = (
+    overrides?: TBotRuntimeMessageOverrides,
+) => IBotRuntimeMessages;
+
+/**
+ * Creates a collection of runtime messages. Consumers can provide overrides to localise or
+ * customise responses that are used by the runtime for logging and validation feedback.
+ * Passing a factory via {@link BotRuntimeMessageFactory} allows plugging in a translation
+ * system while reusing {@link DEFAULT_BOT_RUNTIME_MESSAGES} as a fallback.
+ */
+export const createBotRuntimeMessages: BotRuntimeMessageFactory = (
+    overrides = {},
+) => ({
+    ...DEFAULT_BOT_RUNTIME_MESSAGES,
+    ...overrides,
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,11 @@ export {
     normalizeBotOptions,
 } from './builder/bot-runtime';
 export {
+    createBotRuntimeMessages,
+    DEFAULT_BOT_RUNTIME_MESSAGES,
+    BotRuntimeMessageFactory,
+} from './builder/builder.messages';
+export {
     PageNavigator,
     PageNavigatorFactoryOptions,
     IValidationResult,
@@ -54,6 +59,7 @@ export {
     IBotPageMiddlewareConfig,
     IBotPageMiddlewareResult,
     IBotPageNavigationOptions,
+    IBotRuntimeMessages,
     IBotSessionState,
     IBotSessionStorage,
     TBotKeyboardMarkup,
@@ -69,4 +75,5 @@ export {
     TBotPageMiddleware,
     TBotPageMiddlewareHandler,
     TBotPageMiddlewareHandlerResult,
+    TBotRuntimeMessageOverrides,
 } from './app.interface';


### PR DESCRIPTION
## Summary
- add bot runtime message contracts and default implementations for localisation
- replace BotRuntime log and validation strings with configurable messages
- export the message factory so clients can override defaults

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cec48f9d2c83288711d5bfac589cf3