### PR TITLE
docs: add runtime jsdoc

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -14,6 +14,10 @@ const BOT_BUILDER_BOTS_REGISTRATION = Symbol('BOT_BUILDER_BOTS_REGISTRATION');
 
 @Module({})
 export class BotBuilder {
+    /**
+     * Configures the builder module for asynchronous initialization, wiring
+     * factories that register bots once dependencies resolve.
+     */
     static forRootAsync(options: IBotBuilderModuleAsyncOptions): DynamicModule {
         const asyncOptions = this.createAsyncOptionsProvider(options);
         const botsRegistration = this.createBotsRegistrationProvider();
@@ -37,6 +41,10 @@ export class BotBuilder {
         };
     }
 
+    /**
+     * Registers additional bot configurations in feature modules using the
+     * shared builder service.
+     */
     static forFeature(
         options: IBotBuilderOptions | IBotBuilderOptions[],
     ): DynamicModule {
@@ -58,6 +66,10 @@ export class BotBuilder {
         };
     }
 
+    /**
+     * Creates a provider that resolves module options through the consumer's
+     * asynchronous factory.
+     */
     private static createAsyncOptionsProvider(
         options: IBotBuilderModuleAsyncOptions,
     ): Provider {
@@ -71,6 +83,10 @@ export class BotBuilder {
         };
     }
 
+    /**
+     * Sets up a provider responsible for bootstrapping bot runtimes once the
+     * builder service and configuration are available.
+     */
     private static createBotsRegistrationProvider(): Provider {
         return {
             provide: BOT_BUILDER_BOTS_REGISTRATION,
@@ -85,6 +101,10 @@ export class BotBuilder {
         };
     }
 
+    /**
+     * Supplies the Prisma client from whichever bot configuration declares it,
+     * allowing downstream injections to reuse the instance.
+     */
     private static createPrismaProvider(): Provider {
         return {
             provide: BOT_BUILDER_PRISMA,
@@ -94,6 +114,10 @@ export class BotBuilder {
         };
     }
 
+    /**
+     * Normalizes incoming builder options, accepting both builder and runtime
+     * shapes while ensuring each entry has resolved defaults.
+     */
     private static normalizeOptions(
         options:
             | IBotBuilderOptions

--- a/src/builder/builder.service.ts
+++ b/src/builder/builder.service.ts
@@ -17,6 +17,10 @@ export class BuilderService {
     private readonly botOptions = new Map<string, IBotRuntimeOptions>();
     private readonly tokenToBotId = new Map<string, string>();
 
+    /**
+     * Creates a builder instance that keeps track of registered runtimes and
+     * optional Prisma dependencies injected from the Nest container.
+     */
     constructor(
         private readonly logger: PublisherService,
         @Optional()
@@ -24,6 +28,10 @@ export class BuilderService {
         private readonly prismaService?: PrismaClient,
     ) {}
 
+    /**
+     * Registers one or multiple bots described by the given options and returns
+     * the resolved bot identifiers in registration order.
+     */
     public registerBots(
         options: IBotBuilderOptions | IBotBuilderOptions[] = [],
     ): string[] {
@@ -31,11 +39,19 @@ export class BuilderService {
         return list.map((option, index) => this.registerBot(option, index));
     }
 
+    /**
+     * Normalizes builder options for a single bot and registers the
+     * corresponding runtime instance.
+     */
     public registerBot(options: IBotBuilderOptions, index?: number): string {
         const normalized = normalizeBotOptions(options, index);
         return this.registerNormalizedBot(normalized);
     }
 
+    /**
+     * Registers a bot runtime using already normalized options, replacing any
+     * previously running runtime that shares the same id or token.
+     */
     public registerNormalizedBot(options: IBotRuntimeOptions): string {
         const botId = options.id;
 
@@ -68,6 +84,10 @@ export class BuilderService {
         return botId;
     }
 
+    /**
+     * Stops and removes the runtime associated with the provided bot id if it
+     * is currently registered.
+     */
     private removeBot(botId: string): void {
         const runtime = this.bots.get(botId);
         if (!runtime) {
@@ -87,6 +107,10 @@ export class BuilderService {
         }
     }
 
+    /**
+     * Cleans internal caches and token associations for the specified bot
+     * runtime.
+     */
     private detachBot(botId: string, runtime: BotRuntime): void {
         const options = this.botOptions.get(botId);
         const token = options?.TG_BOT_TOKEN ?? runtime.token;
@@ -98,6 +122,10 @@ export class BuilderService {
         this.clearTokenMapping(token, botId);
     }
 
+    /**
+     * Removes the token-to-bot mapping when it is no longer associated with the
+     * provided bot id.
+     */
     private clearTokenMapping(token?: string, botId?: string): void {
         if (!token) {
             return;

--- a/src/builder/runtime/middleware-pipeline.ts
+++ b/src/builder/runtime/middleware-pipeline.ts
@@ -14,11 +14,19 @@ export interface BuildMiddlewarePipelineOptions<TArgs extends unknown[]> {
     onError?: (error: unknown) => void;
 }
 
+/**
+ * Returns a new list of middleware configs sorted by descending priority so
+ * higher-priority entries execute earlier.
+ */
 export const sortMiddlewareConfigs = <T extends { priority?: number }>(
     middlewares: T[] = [],
 ): T[] =>
     [...middlewares].sort((a, b) => (b.priority ?? 0) - (a.priority ?? 0));
 
+/**
+ * Merges global and handler-level middleware configurations while preserving
+ * relative priority ordering between both sources.
+ */
 export const mergeMiddlewareConfigs = (
     globalMiddlewares: IBotMiddlewareConfig[] = [],
     handlerMiddlewares: IBotMiddlewareConfig[] = [],
@@ -68,6 +76,10 @@ export const mergeMiddlewareConfigs = (
     return result;
 };
 
+/**
+ * Builds an executable pipeline that invokes configured middlewares before the
+ * target handler, propagating a shared context and error hook.
+ */
 export const buildMiddlewarePipeline = <TArgs extends unknown[]>(
     options: BuildMiddlewarePipelineOptions<TArgs>,
 ) => {

--- a/src/builder/runtime/session-manager.ts
+++ b/src/builder/runtime/session-manager.ts
@@ -22,6 +22,10 @@ export class SessionManager {
 
     private readonly sessionCache = new Map<string, IChatSessionState>();
 
+    /**
+     * Initializes the session manager with either the provided storage backend
+     * or an in-memory fallback.
+     */
     constructor(options: SessionManagerOptions = {}) {
         this.sessionStorage =
             options.sessionStorage ??
@@ -30,6 +34,10 @@ export class SessionManager {
             >);
     }
 
+    /**
+     * Retrieves a chat session from cache or storage, normalizing legacy data
+     * formats into the unified structure.
+     */
     public async getSession(
         chatId: TelegramBot.ChatId,
     ): Promise<IChatSessionState> {
@@ -49,6 +57,9 @@ export class SessionManager {
         return session;
     }
 
+    /**
+     * Persists the provided session state and updates the in-memory cache.
+     */
     public async saveSession(
         chatId: TelegramBot.ChatId,
         session: IChatSessionState,
@@ -58,6 +69,10 @@ export class SessionManager {
         await this.sessionStorage.set(chatId, session);
     }
 
+    /**
+     * Removes the chat session from cache and underlying storage when
+     * supported by the backend.
+     */
     public async deleteSession(chatId: TelegramBot.ChatId): Promise<void> {
         const key = chatId.toString();
         this.sessionCache.delete(key);
@@ -66,6 +81,10 @@ export class SessionManager {
         }
     }
 
+    /**
+     * Transforms stored session representations into the shape expected by the
+     * runtime, supporting both legacy and new formats.
+     */
     private normalizeSessionState(
         stored?: IChatSessionState | IBotSessionState | null,
     ): IChatSessionState | undefined {
@@ -88,6 +107,9 @@ export class SessionManager {
         return undefined;
     }
 
+    /**
+     * Type guard that identifies already-normalized chat session states.
+     */
     private isChatSessionState(value: unknown): value is IChatSessionState {
         return (
             typeof value === 'object' &&
@@ -97,12 +119,20 @@ export class SessionManager {
         );
     }
 
+    /**
+     * Type guard distinguishing plain session state objects persisted by older
+     * builder versions.
+     */
     private isSessionState(value: unknown): value is IBotSessionState {
         return (
             typeof value === 'object' && value !== null && !Array.isArray(value)
         );
     }
 
+    /**
+     * Provides a minimal in-memory session storage implementation used when no
+     * external storage is supplied.
+     */
     private createDefaultSessionStorage(): IBotSessionStorage<IChatSessionState> {
         const store = new Map<string, IChatSessionState>();
         return {
@@ -119,6 +149,9 @@ export class SessionManager {
 
 export interface SessionManagerFactoryOptions extends SessionManagerOptions {}
 
+/**
+ * Factory that builds the default session manager instance.
+ */
 export const createSessionManager = (
     options: SessionManagerFactoryOptions = {},
 ): SessionManager => new SessionManager(options);

--- a/src/builder/utils/serialization.ts
+++ b/src/builder/utils/serialization.ts
@@ -6,6 +6,10 @@ export interface IStepHistoryEntry {
     timestamp: string;
 }
 
+/**
+ * Converts arbitrary values into a Prisma JSON-friendly representation while
+ * preserving nested structures.
+ */
 export const serializeValue = (value: unknown): TPrismaJsonValue | null => {
     if (value === undefined) {
         return null;
@@ -40,6 +44,10 @@ export const serializeValue = (value: unknown): TPrismaJsonValue | null => {
     return null;
 };
 
+/**
+ * Produces a shallow copy of stored answers, ensuring the result is a record
+ * even when invalid data is received.
+ */
 export const normalizeAnswers = (
     answers: unknown,
 ): Record<string, TPrismaJsonValue | null> => {
@@ -52,6 +60,10 @@ export const normalizeAnswers = (
     };
 };
 
+/**
+ * Cleans up persisted history entries to a predictable shape and re-serializes
+ * nested values.
+ */
 export const normalizeHistory = (history: unknown): IStepHistoryEntry[] => {
     if (!Array.isArray(history)) {
         return [];


### PR DESCRIPTION
## Summary
- add JSDoc documentation to the builder service and runtime initialization flow
- clarify helper runtime components and factories with contextual comments
- document serialization utilities and module configuration helpers for future maintainers

## Testing
- npm run lint *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68ced089688483289c6e17ed0900b77c