### PR TITLE
docs: document custom persistence gateway example

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,17 +322,21 @@ class ExistingModelsGateway implements IPersistenceGateway {
             },
         });
 
+        const targetPageId = currentPageId ?? session.pageId;
+
         const stepState = await this.db.stepState.upsert({
             where: { userId_slug: { userId: user.id, slug: this.slug } },
             update: {
                 chatId: chatIdentifier,
-                currentPage: currentPageId ?? session.pageId ?? null,
+                ...(targetPageId !== undefined
+                    ? { currentPage: targetPageId }
+                    : {}),
             },
             create: {
                 userId: user.id,
                 chatId: chatIdentifier,
                 slug: this.slug,
-                currentPage: null,
+                currentPage: targetPageId ?? null,
                 answers: session.data ?? {},
                 history: [],
             },

--- a/README.md
+++ b/README.md
@@ -145,7 +145,6 @@ model User {
   updatedAt    DateTime    @updatedAt
   stepStates   StepState[]
   formEntries  FormEntry[]
-  Wallet       Wallet[]
 }
 
 model StepState {

--- a/src/app.interface.ts
+++ b/src/app.interface.ts
@@ -2,6 +2,7 @@ import { ModuleMetadata } from '@nestjs/common';
 import type TelegramBot from 'node-telegram-bot-api';
 import type { AnySchema } from 'yup';
 import type { PrismaClient } from '@prisma/client/extension';
+import type { BotRuntimeDependencies } from './builder/bot-runtime';
 
 export type TPrismaJsonValue =
     | string
@@ -236,6 +237,7 @@ export interface IBotBuilderOptions {
     services?: Record<string, unknown>;
     pageMiddlewares?: IBotPageMiddlewareConfig[];
     messages?: TBotRuntimeMessageOverrides;
+    dependencies?: BotRuntimeDependencies;
 }
 
 export interface IBotBuilderModuleAsyncOptions

--- a/src/builder/builder.service.ts
+++ b/src/builder/builder.service.ts
@@ -193,6 +193,9 @@ export class BuilderService {
             keyboards: [...(options.keyboards ?? [])],
             services: { ...(options.services ?? {}) },
             pageMiddlewares: [...(options.pageMiddlewares ?? [])],
+            dependencies: options.dependencies
+                ? { ...options.dependencies }
+                : undefined,
         };
     }
 }

--- a/src/builder/builder.service.ts
+++ b/src/builder/builder.service.ts
@@ -74,6 +74,7 @@ export class BuilderService {
             options,
             this.logger,
             this.prismaService,
+            options.dependencies ? { ...options.dependencies } : undefined,
         );
         this.bots.set(botId, runtime);
         this.botInstances.set(botId, runtime.bot);

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,6 +48,8 @@ export {
     BOT_BUILDER_PRISMA,
 } from './app.constants';
 export {
+    IPrismaUser,
+    IPrismaStepState,
     IBotBuilderModuleAsyncOptions,
     IBotBuilderOptions,
     IBotBuilderContext,


### PR DESCRIPTION
## Summary
- document how to replace the built-in Prisma gateway via `dependencies.persistenceGatewayFactory`
- add a full example adapter that maps existing domain models to `IPrismaUser`/`IPrismaStepState`
- show how to register the custom gateway inside `BotBuilder.forRootAsync`

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d57377095083288db7d9c71f15db23