### PR TITLE
Configure Jest testing infrastructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -547,6 +547,20 @@ const dependencies: BotRuntimeDependencies = {
 
 This approach enables centralized multilingual support or integration with an existing localization service.
 
+## 10. Testing and coverage
+
+Jest is configured with `ts-jest` so that TypeScript sources and NestJS testing utilities work out of the box. The test harness
+loads `reflect-metadata`, mocks timer utilities from `@nestjs/testing`, and clears mocks between runs. To execute tests or collect
+coverage locally and in CI/CD, use the following commands:
+
+```bash
+npm test           # single test run
+npm run test:watch # watch mode for local development
+npm run test:cov   # run the suite with coverage reporting
+```
+
+Coverage artifacts are emitted to the `coverage` directory, making it easy to upload reports from CI pipelines.
+
 ---
 
 Following these steps you can build predictable, extensible, and reliable Telegram bot flows on top of NestJS.

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,0 +1,30 @@
+import type { Config } from 'jest';
+import { pathsToModuleNameMapper } from 'ts-jest';
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { compilerOptions } = require('./tsconfig.json');
+
+const config: Config = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'json'],
+  roots: ['<rootDir>/src', '<rootDir>/test'],
+  testMatch: ['**/?(*.)+(spec|test).ts'],
+  collectCoverageFrom: ['<rootDir>/src/**/*.ts'],
+  coverageDirectory: '<rootDir>/coverage',
+  setupFilesAfterEnv: ['<rootDir>/test/setup/jest.setup.ts'],
+  passWithNoTests: true,
+  moduleNameMapper: {
+    '^@nestjs/(.*)$': '<rootDir>/node_modules/@nestjs/$1',
+    ...pathsToModuleNameMapper(compilerOptions?.paths ?? {}, {
+      prefix: '<rootDir>/',
+    }),
+  },
+  globals: {
+    'ts-jest': {
+      tsconfig: '<rootDir>/tsconfig.spec.json',
+    },
+  },
+};
+
+export default config;

--- a/package.json
+++ b/package.json
@@ -19,7 +19,10 @@
     "scripts": {
         "build": "tsc",
         "distribute": "npm run build && npm publish",
-        "p": "npx prettier . --write"
+        "p": "npx prettier . --write",
+        "test": "jest",
+        "test:watch": "npm run test -- --watch",
+        "test:cov": "npm run test -- --coverage"
     },
     "repository": {
         "type": "git",

--- a/test/setup/jest.setup.ts
+++ b/test/setup/jest.setup.ts
@@ -1,0 +1,34 @@
+import 'reflect-metadata';
+
+type NestTesting = typeof import('@nestjs/testing');
+
+jest.mock('@nestjs/testing', (): NestTesting => {
+  const actual: NestTesting = jest.requireActual('@nestjs/testing');
+  const patched = actual.Test.createTestingModule as typeof actual.Test.createTestingModule & {
+    __jestPatched?: boolean;
+  };
+
+  if (!patched.__jestPatched) {
+    const originalCreateTestingModule = patched.bind(actual.Test);
+    const wrappedCreateTestingModule = (
+      ...args: Parameters<typeof originalCreateTestingModule>
+    ) => {
+      jest.useFakeTimers();
+      return originalCreateTestingModule(...args);
+    };
+
+    (wrappedCreateTestingModule as typeof patched).__jestPatched = true;
+    actual.Test.createTestingModule = wrappedCreateTestingModule;
+  }
+
+  return actual;
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+afterEach(() => {
+  jest.clearAllTimers();
+  jest.useRealTimers();
+});

--- a/tsconfig.spec.json
+++ b/tsconfig.spec.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "types": ["jest", "node"],
+    "sourceMap": true
+  },
+  "include": ["src/**/*.ts", "test/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary
- add a ts-jest based Jest configuration with Nest-friendly module mapping and shared setup
- introduce a dedicated tsconfig for specs and update npm scripts for running the suite and coverage
- provide a Jest environment setup that loads reflect-metadata, stabilises Nest timers, and document the workflow in the README

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d7cf7d24cc8328bdfe68cc6c296f27