### PR TITLE
Add reusable test mocks and builder factories

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,15 +3,18 @@
 ## 1. About the library
 
 ### Purpose
+
 `tg-bot-builder` is a NestJS module that wraps `node-telegram-bot-api` with a declarative step-by-step builder for Telegram bots. It lets you describe a dialogue as a list of pages (steps) with validators, handlers, and middlewares while keeping user answers in sync with the session storage and a database.
 
 ### Problems it solves
-* **Repeatable infrastructure.** The library eliminates the need to bootstrap the client, polling, session storage, and per-message context manually. All of that is orchestrated by a `BotRuntime` instance created by the `BuilderService`.
-* **Complex validations and transitions.** Instead of handling every incoming message yourself, you can describe steps with Yup schemas or custom validation functions. Navigation logic is encapsulated in `next` handlers.
-* **Built-in persistence.** The provided `PrismaPersistenceGateway` synchronizes users, step states, answer history, and `FormEntry` rows, so you do not have to write infrastructural code to save progress.
-* **Extensibility.** Every component (Prisma provider, session manager, message factory, persistence gateway) can be replaced without rewriting your flows. This is handy for localization, custom databases, or distributed storage.
+
+- **Repeatable infrastructure.** The library eliminates the need to bootstrap the client, polling, session storage, and per-message context manually. All of that is orchestrated by a `BotRuntime` instance created by the `BuilderService`.
+- **Complex validations and transitions.** Instead of handling every incoming message yourself, you can describe steps with Yup schemas or custom validation functions. Navigation logic is encapsulated in `next` handlers.
+- **Built-in persistence.** The provided `PrismaPersistenceGateway` synchronizes users, step states, answer history, and `FormEntry` rows, so you do not have to write infrastructural code to save progress.
+- **Extensibility.** Every component (Prisma provider, session manager, message factory, persistence gateway) can be replaced without rewriting your flows. This is handy for localization, custom databases, or distributed storage.
 
 ### Key principles
+
 1. **Pages as steps.** Scenarios are described with `IBotPage[]`. Each page manages its content, validation, and navigation.
 2. **Runtime wrapper around Telegram Bot API.** `BotRuntime` registers event handlers, builds context, and executes the middleware pipeline. It extracts user input, validates it, invokes `onValid`, determines the next page, and renders content through the `PageNavigator`.
 3. **State and persistence.** `SessionManager` keeps chat sessions in memory (or in a custom `IBotSessionStorage`), while an `IPersistenceGateway` syncs the state to a database. If Prisma is not connected, the runtime falls back to `NoopPersistenceGateway` and works fully in memory.
@@ -23,17 +26,18 @@ A page implements `IBotPage` and supports the fields `id`, `content`, `validate`
 
 ```ts
 const pages: IBotPage[] = [
-  {
-    id: 'phone',
-    content: 'Send your phone number',
-    yup: yup.string().required(),
-    onValid: async (ctx) => ctx.bot.sendMessage(ctx.chatId, 'Thank you!'),
-    next: () => 'summary',
-  },
+    {
+        id: 'phone',
+        content: 'Send your phone number',
+        yup: yup.string().required(),
+        onValid: async (ctx) => ctx.bot.sendMessage(ctx.chatId, 'Thank you!'),
+        next: () => 'summary',
+    },
 ];
 ```
 
 ### Processing order for an incoming message
+
 1. **Load the session.** `SessionManager.getSession` reads the chat state. The user from the message is merged into the session.
 2. **Prepare context.** `BotRuntime.prepareContext` calls `IPersistenceGateway.ensureDatabaseState` to ensure that a user and `StepState` exist in the database. The context contains `bot`, `chatId`, `session`, `db`, `services`, and the current `message`/`metadata`.
 3. **Resolve the current page.** If no page is assigned, the runtime calls `PageNavigator.resolveInitialPage` and renders the initial step.
@@ -50,9 +54,10 @@ This lifecycle provides a predictable, testable conversation flow with full cont
 ## 3. Installation and setup
 
 1. Install the package and its peer dependency:
-   ```bash
-   npm install tg-bot-builder node-telegram-bot-api
-   ```
+
+    ```bash
+    npm install tg-bot-builder node-telegram-bot-api
+    ```
 
 2. Import the module in your `AppModule` and register a bot configuration:
 
@@ -62,32 +67,35 @@ import { BotBuilder, IBotBuilderOptions } from 'tg-bot-builder';
 import { PrismaService } from './prisma.service';
 
 @Module({
-  imports: [
-    BotBuilder.forRootAsync({
-      imports: [],
-      inject: [PrismaService],
-      useFactory: async (prisma: PrismaService): Promise<IBotBuilderOptions[]> => [
-        {
-          TG_BOT_TOKEN: process.env.TG_TOKEN!,
-          slug: 'onboarding',
-          prisma,
-          initialPageId: 'welcome',
-          pages: [
-            {
-              id: 'welcome',
-              content: 'Hello! What is your name?',
-              yup: yup.string().required(),
-              next: () => 'done',
-            },
-            {
-              id: 'done',
-              content: (ctx) => `Thank you, ${ctx.session?.welcome}!`,
-            },
-          ],
-        },
-      ],
-    }),
-  ],
+    imports: [
+        BotBuilder.forRootAsync({
+            imports: [],
+            inject: [PrismaService],
+            useFactory: async (
+                prisma: PrismaService,
+            ): Promise<IBotBuilderOptions[]> => [
+                {
+                    TG_BOT_TOKEN: process.env.TG_TOKEN!,
+                    slug: 'onboarding',
+                    prisma,
+                    initialPageId: 'welcome',
+                    pages: [
+                        {
+                            id: 'welcome',
+                            content: 'Hello! What is your name?',
+                            yup: yup.string().required(),
+                            next: () => 'done',
+                        },
+                        {
+                            id: 'done',
+                            content: (ctx) =>
+                                `Thank you, ${ctx.session?.welcome}!`,
+                        },
+                    ],
+                },
+            ],
+        }),
+    ],
 })
 export class AppModule {}
 ```
@@ -146,21 +154,21 @@ import { BotRegistryService } from 'tg-bot-builder';
 
 @Controller('bots')
 export class BotsController {
-  constructor(private readonly registry: BotRegistryService) {}
+    constructor(private readonly registry: BotRegistryService) {}
 
-  @Get()
-  list() {
-    return this.registry.listBots();
-  }
-
-  @Post(':id/broadcast')
-  async broadcast(@Param('id') id: string, @Body('message') message: string) {
-    const bot = this.registry.getTelegramBot(id);
-    if (!bot) {
-      throw new Error('Bot not found');
+    @Get()
+    list() {
+        return this.registry.listBots();
     }
-    await bot.sendMessage(process.env.ADMIN_CHAT_ID!, message);
-  }
+
+    @Post(':id/broadcast')
+    async broadcast(@Param('id') id: string, @Body('message') message: string) {
+        const bot = this.registry.getTelegramBot(id);
+        if (!bot) {
+            throw new Error('Bot not found');
+        }
+        await bot.sendMessage(process.env.ADMIN_CHAT_ID!, message);
+    }
 }
 ```
 
@@ -288,218 +296,218 @@ Below is a complete `PrismaGateway` implementation you can copy and adapt. Model
 import { Prisma, PrismaClient } from '@prisma/client';
 import TelegramBot from 'node-telegram-bot-api';
 import {
-  IBotSessionState,
-  IChatSessionState,
-  IContextDatabaseState,
-  IPersistenceGateway,
-  IPrismaStepState,
-  IPrismaUser,
-  normalizeAnswers,
-  normalizeChatId,
-  normalizeHistory,
-  normalizeTelegramId,
-  serializeValue,
+    IBotSessionState,
+    IChatSessionState,
+    IContextDatabaseState,
+    IPersistenceGateway,
+    IPrismaStepState,
+    IPrismaUser,
+    normalizeAnswers,
+    normalizeChatId,
+    normalizeHistory,
+    normalizeTelegramId,
+    serializeValue,
 } from 'tg-bot-builder';
 import { isDeepStrictEqual } from 'util';
 
 export class PrismaGateway implements IPersistenceGateway {
-  prisma: PrismaClient;
-  constructor(
-    private readonly db: PrismaClient,
-    private readonly slug: string,
-  ) {
-    this.prisma = db;
-  }
-
-  public async ensureDatabaseState(
-    chatId: TelegramBot.ChatId,
-    session: IChatSessionState,
-    message?: TelegramBot.Message,
-    currentPageId?: string,
-  ): Promise<IContextDatabaseState> {
-    const telegramUser = message?.from ?? session.user;
-    if (!telegramUser) {
-      return {};
+    prisma: PrismaClient;
+    constructor(
+        private readonly db: PrismaClient,
+        private readonly slug: string,
+    ) {
+        this.prisma = db;
     }
 
-    const telegramId = normalizeTelegramId(telegramUser.id);
-    const chatIdentifier = normalizeChatId(chatId);
+    public async ensureDatabaseState(
+        chatId: TelegramBot.ChatId,
+        session: IChatSessionState,
+        message?: TelegramBot.Message,
+        currentPageId?: string,
+    ): Promise<IContextDatabaseState> {
+        const telegramUser = message?.from ?? session.user;
+        if (!telegramUser) {
+            return {};
+        }
 
-    const user = (await this.db.botUser.upsert({
-      where: { telegramId },
-      update: {
-        chatId: chatIdentifier,
-        username: telegramUser.username ?? undefined,
-        firstName: telegramUser.first_name ?? undefined,
-        lastName: telegramUser.last_name ?? undefined,
-        languageCode: telegramUser.language_code ?? undefined,
-      },
-      create: {
-        telegramId,
-        chatId: chatIdentifier,
-        username: telegramUser.username,
-        firstName: telegramUser.first_name,
-        lastName: telegramUser.last_name,
-        languageCode: telegramUser.language_code,
-      },
-    })) as unknown as IPrismaUser;
+        const telegramId = normalizeTelegramId(telegramUser.id);
+        const chatIdentifier = normalizeChatId(chatId);
 
-    const targetPageId = currentPageId ?? session.pageId;
+        const user = (await this.db.botUser.upsert({
+            where: { telegramId },
+            update: {
+                chatId: chatIdentifier,
+                username: telegramUser.username ?? undefined,
+                firstName: telegramUser.first_name ?? undefined,
+                lastName: telegramUser.last_name ?? undefined,
+                languageCode: telegramUser.language_code ?? undefined,
+            },
+            create: {
+                telegramId,
+                chatId: chatIdentifier,
+                username: telegramUser.username,
+                firstName: telegramUser.first_name,
+                lastName: telegramUser.last_name,
+                languageCode: telegramUser.language_code,
+            },
+        })) as unknown as IPrismaUser;
 
-    let stepState = (await this.db.stepState.findUnique({
-      where: {
-        userId_slug: {
-          userId: user.id,
-          slug: this.slug,
-        },
-      },
-    })) as unknown as IPrismaStepState | null;
+        const targetPageId = currentPageId ?? session.pageId;
 
-    if (!stepState) {
-      stepState = (await this.db.stepState.create({
-        data: {
-          userId: user.id,
-          chatId: chatIdentifier,
-          slug: this.slug,
-          currentPage: targetPageId ?? null,
-          answers: serializeValue(
-            session.data ?? {},
-            Prisma.JsonNull,
-          ),
-          history: serializeValue([], Prisma.JsonNull),
-        },
-      })) as unknown as IPrismaStepState;
-    } else {
-      const updates: Record<string, unknown> = {};
+        let stepState = (await this.db.stepState.findUnique({
+            where: {
+                userId_slug: {
+                    userId: user.id,
+                    slug: this.slug,
+                },
+            },
+        })) as unknown as IPrismaStepState | null;
 
-      if (stepState.chatId !== chatIdentifier) {
-        updates.chatId = chatIdentifier;
-      }
+        if (!stepState) {
+            stepState = (await this.db.stepState.create({
+                data: {
+                    userId: user.id,
+                    chatId: chatIdentifier,
+                    slug: this.slug,
+                    currentPage: targetPageId ?? null,
+                    answers: serializeValue(
+                        session.data ?? {},
+                        Prisma.JsonNull,
+                    ),
+                    history: serializeValue([], Prisma.JsonNull),
+                },
+            })) as unknown as IPrismaStepState;
+        } else {
+            const updates: Record<string, unknown> = {};
 
-      if (
-        targetPageId !== undefined &&
-        stepState.currentPage !== targetPageId
-      ) {
-        updates.currentPage = targetPageId;
-      }
+            if (stepState.chatId !== chatIdentifier) {
+                updates.chatId = chatIdentifier;
+            }
 
-      if (Object.keys(updates).length > 0) {
-        stepState = (await this.db.stepState.update({
-          where: { id: stepState.id },
-          data: updates,
+            if (
+                targetPageId !== undefined &&
+                stepState.currentPage !== targetPageId
+            ) {
+                updates.currentPage = targetPageId;
+            }
+
+            if (Object.keys(updates).length > 0) {
+                stepState = (await this.db.stepState.update({
+                    where: { id: stepState.id },
+                    data: updates,
+                })) as unknown as IPrismaStepState;
+            }
+        }
+
+        return {
+            user,
+            stepState,
+        };
+    }
+
+    public async persistStepProgress(
+        stepState: IPrismaStepState | undefined,
+        pageId: string,
+        value: unknown,
+    ): Promise<IPrismaStepState | undefined> {
+        if (!stepState) {
+            return stepState;
+        }
+
+        const serializedValue = serializeValue(value, Prisma.JsonNull);
+        const answers = normalizeAnswers(stepState.answers, Prisma.JsonNull);
+        answers[pageId] = serializedValue;
+
+        const history = normalizeHistory(stepState.history, Prisma.JsonNull);
+        history.push({
+            pageId,
+            value: serializedValue,
+            timestamp: new Date().toISOString(),
+        });
+
+        const updatedStepState = (await this.db.stepState.update({
+            where: { id: stepState.id },
+            data: {
+                answers: serializeValue(answers, Prisma.JsonNull),
+                history: serializeValue(history, Prisma.JsonNull),
+            },
         })) as unknown as IPrismaStepState;
-      }
+
+        await this.db.formEntry.upsert({
+            where: {
+                stepStateId_pageId: {
+                    stepStateId: updatedStepState.id,
+                    pageId,
+                },
+            },
+            update: {
+                payload: serializedValue,
+            },
+            create: {
+                userId: updatedStepState.userId,
+                stepStateId: updatedStepState.id,
+                slug: updatedStepState.slug,
+                pageId,
+                payload: serializedValue,
+            },
+        });
+
+        return updatedStepState;
     }
 
-    return {
-      user,
-      stepState,
-    };
-  }
+    public async syncSessionState(
+        stepState: IPrismaStepState | undefined,
+        sessionData: IBotSessionState,
+    ): Promise<IPrismaStepState | undefined> {
+        if (!stepState) {
+            return stepState;
+        }
 
-  public async persistStepProgress(
-    stepState: IPrismaStepState | undefined,
-    pageId: string,
-    value: unknown,
-  ): Promise<IPrismaStepState | undefined> {
-    if (!stepState) {
-      return stepState;
+        const serializedSession = serializeValue(
+            sessionData ?? {},
+            Prisma.JsonNull,
+        );
+        const normalizedSession = normalizeAnswers(
+            serializedSession ?? {},
+            null,
+        );
+        const normalizedExisting = normalizeAnswers(
+            stepState.answers,
+            Prisma.JsonNull,
+        );
+
+        if (isDeepStrictEqual(normalizedExisting, normalizedSession)) {
+            return stepState;
+        }
+
+        return (await this.db.stepState.update({
+            where: { id: stepState.id },
+            data: {
+                answers: serializedSession ?? {},
+            },
+        })) as unknown as IPrismaStepState;
     }
 
-    const serializedValue = serializeValue(value, Prisma.JsonNull);
-    const answers = normalizeAnswers(stepState.answers, Prisma.JsonNull);
-    answers[pageId] = serializedValue;
+    public async updateStepStateCurrentPage(
+        stepState: IPrismaStepState | undefined,
+        pageId: string | undefined,
+    ): Promise<IPrismaStepState | undefined> {
+        if (!stepState) {
+            return stepState;
+        }
 
-    const history = normalizeHistory(stepState.history, Prisma.JsonNull);
-    history.push({
-      pageId,
-      value: serializedValue,
-      timestamp: new Date().toISOString(),
-    });
+        const targetPage = pageId ?? null;
+        if (stepState.currentPage === targetPage) {
+            return stepState;
+        }
 
-    const updatedStepState = (await this.db.stepState.update({
-      where: { id: stepState.id },
-      data: {
-        answers: serializeValue(answers, Prisma.JsonNull),
-        history: serializeValue(history, Prisma.JsonNull),
-      },
-    })) as unknown as IPrismaStepState;
-
-    await this.db.formEntry.upsert({
-      where: {
-        stepStateId_pageId: {
-          stepStateId: updatedStepState.id,
-          pageId,
-        },
-      },
-      update: {
-        payload: serializedValue,
-      },
-      create: {
-        userId: updatedStepState.userId,
-        stepStateId: updatedStepState.id,
-        slug: updatedStepState.slug,
-        pageId,
-        payload: serializedValue,
-      },
-    });
-
-    return updatedStepState;
-  }
-
-  public async syncSessionState(
-    stepState: IPrismaStepState | undefined,
-    sessionData: IBotSessionState,
-  ): Promise<IPrismaStepState | undefined> {
-    if (!stepState) {
-      return stepState;
+        return (await this.db.stepState.update({
+            where: { id: stepState.id },
+            data: {
+                currentPage: targetPage,
+            },
+        })) as unknown as IPrismaStepState;
     }
-
-    const serializedSession = serializeValue(
-      sessionData ?? {},
-      Prisma.JsonNull,
-    );
-    const normalizedSession = normalizeAnswers(
-      serializedSession ?? {},
-      null,
-    );
-    const normalizedExisting = normalizeAnswers(
-      stepState.answers,
-      Prisma.JsonNull,
-    );
-
-    if (isDeepStrictEqual(normalizedExisting, normalizedSession)) {
-      return stepState;
-    }
-
-    return (await this.db.stepState.update({
-      where: { id: stepState.id },
-      data: {
-        answers: serializedSession ?? {},
-      },
-    })) as unknown as IPrismaStepState;
-  }
-
-  public async updateStepStateCurrentPage(
-    stepState: IPrismaStepState | undefined,
-    pageId: string | undefined,
-  ): Promise<IPrismaStepState | undefined> {
-    if (!stepState) {
-      return stepState;
-    }
-
-    const targetPage = pageId ?? null;
-    if (stepState.currentPage === targetPage) {
-      return stepState;
-    }
-
-    return (await this.db.stepState.update({
-      where: { id: stepState.id },
-      data: {
-        currentPage: targetPage,
-      },
-    })) as unknown as IPrismaStepState;
-  }
 }
 ```
 
@@ -507,9 +515,9 @@ export class PrismaGateway implements IPersistenceGateway {
 
 When a bot configuration omits the `prisma` option, `createPersistenceGateway` returns a `NoopPersistenceGateway`. In this mode:
 
-* No database is touched; state lives entirely in memory via the `SessionManager` map-based storage.
-* `persistStepProgress`, `syncSessionState`, and `updateStepStateCurrentPage` are no-ops that return the existing state.
-* You can still plug in an external session store (e.g., Redis) by passing a custom `sessionStorage` implementation.
+- No database is touched; state lives entirely in memory via the `SessionManager` map-based storage.
+- `persistStepProgress`, `syncSessionState`, and `updateStepStateCurrentPage` are no-ops that return the existing state.
+- You can still plug in an external session store (e.g., Redis) by passing a custom `sessionStorage` implementation.
 
 This setup is useful for prototypes, tests, or when you manage persistence outside of Prisma.
 
@@ -537,11 +545,12 @@ To override the factory itself, use dependencies:
 
 ```ts
 const dependencies: BotRuntimeDependencies = {
-  messageFactory: (overrides) =>
-    createBotRuntimeMessages({
-      ...overrides,
-      middlewareError: ({ event }) => `Middleware error for event ${event}`,
-    }),
+    messageFactory: (overrides) =>
+        createBotRuntimeMessages({
+            ...overrides,
+            middlewareError: ({ event }) =>
+                `Middleware error for event ${event}`,
+        }),
 };
 ```
 

--- a/__mocks__/node-telegram-bot-api.ts
+++ b/__mocks__/node-telegram-bot-api.ts
@@ -1,0 +1,10 @@
+import NodeTelegramBotApiMock from '../test/mocks/node-telegram-bot-api';
+
+type MockClass = typeof NodeTelegramBotApiMock & {
+  default?: typeof NodeTelegramBotApiMock;
+};
+
+const mockClass: MockClass = NodeTelegramBotApiMock;
+mockClass.default = NodeTelegramBotApiMock;
+
+export = mockClass;

--- a/__mocks__/node-telegram-bot-api.ts
+++ b/__mocks__/node-telegram-bot-api.ts
@@ -1,7 +1,7 @@
 import NodeTelegramBotApiMock from '../test/mocks/node-telegram-bot-api';
 
 type MockClass = typeof NodeTelegramBotApiMock & {
-  default?: typeof NodeTelegramBotApiMock;
+    default?: typeof NodeTelegramBotApiMock;
 };
 
 const mockClass: MockClass = NodeTelegramBotApiMock;

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -5,26 +5,26 @@ import { pathsToModuleNameMapper } from 'ts-jest';
 const { compilerOptions } = require('./tsconfig.json');
 
 const config: Config = {
-  preset: 'ts-jest',
-  testEnvironment: 'node',
-  moduleFileExtensions: ['ts', 'tsx', 'js', 'json'],
-  roots: ['<rootDir>/src', '<rootDir>/test'],
-  testMatch: ['**/?(*.)+(spec|test).ts'],
-  collectCoverageFrom: ['<rootDir>/src/**/*.ts'],
-  coverageDirectory: '<rootDir>/coverage',
-  setupFilesAfterEnv: ['<rootDir>/test/setup/jest.setup.ts'],
-  passWithNoTests: true,
-  moduleNameMapper: {
-    '^@nestjs/(.*)$': '<rootDir>/node_modules/@nestjs/$1',
-    ...pathsToModuleNameMapper(compilerOptions?.paths ?? {}, {
-      prefix: '<rootDir>/',
-    }),
-  },
-  globals: {
-    'ts-jest': {
-      tsconfig: '<rootDir>/tsconfig.spec.json',
+    preset: 'ts-jest',
+    testEnvironment: 'node',
+    moduleFileExtensions: ['ts', 'tsx', 'js', 'json'],
+    roots: ['<rootDir>/src', '<rootDir>/test'],
+    testMatch: ['**/?(*.)+(spec|test).ts'],
+    collectCoverageFrom: ['<rootDir>/src/**/*.ts'],
+    coverageDirectory: '<rootDir>/coverage',
+    setupFilesAfterEnv: ['<rootDir>/test/setup/jest.setup.ts'],
+    passWithNoTests: true,
+    moduleNameMapper: {
+        '^@nestjs/(.*)$': '<rootDir>/node_modules/@nestjs/$1',
+        ...pathsToModuleNameMapper(compilerOptions?.paths ?? {}, {
+            prefix: '<rootDir>/',
+        }),
     },
-  },
+    globals: {
+        'ts-jest': {
+            tsconfig: '<rootDir>/tsconfig.spec.json',
+        },
+    },
 };
 
 export default config;

--- a/test/factories/builder.ts
+++ b/test/factories/builder.ts
@@ -1,83 +1,85 @@
 import { Logger } from '@nestjs/common';
 import type { PrismaClient as ActualPrismaClient } from '@prisma/client/extension';
-import type { IBotBuilderOptions } from '../../src/app.interface';
+import type { IBotBuilderOptions } from '../../src';
 import {
-  BotRuntime,
-  BotRuntimeDependencies,
-  IBotRuntimeOptions,
-  normalizeBotOptions,
-} from '../../src/builder/bot-runtime';
-import { BuilderService } from '../../src/builder/builder.service';
+    BotRuntime,
+    BotRuntimeDependencies,
+    IBotRuntimeOptions,
+    normalizeBotOptions,
+} from '../../src';
+import { BuilderService } from '../../src';
 import {
-  createMockPrisma,
-  PrismaClient as MockPrismaClient,
+    createMockPrisma,
+    PrismaClient as MockPrismaClient,
 } from '../mocks/prisma';
 import { createInMemorySessionStorage } from '../mocks/session-storage';
 
 type BotOptionOverrides = Partial<Omit<IBotBuilderOptions, 'prisma'>> & {
-  prisma?: MockPrismaClient | ActualPrismaClient;
+    prisma?: MockPrismaClient | ActualPrismaClient;
 };
 
 export interface CreateTestBotRuntimeOptions extends BotOptionOverrides {
-  logger?: Logger;
-  runtimeDependencies?: BotRuntimeDependencies;
+    logger?: Logger;
+    runtimeDependencies?: BotRuntimeDependencies;
+}
+export interface CreateTestBuilderServiceOptions {
+    prisma?: MockPrismaClient | ActualPrismaClient;
 }
 
 const DEFAULT_BOT_OPTIONS: IBotBuilderOptions = {
-  TG_BOT_TOKEN: 'test-token',
-  id: 'test-bot',
-  pages: [],
-  handlers: [],
-  middlewares: [],
-  keyboards: [],
-  services: {},
-  pageMiddlewares: [],
+    TG_BOT_TOKEN: 'test-token',
+    id: 'test-bot',
+    pages: [],
+    handlers: [],
+    middlewares: [],
+    keyboards: [],
+    services: {},
+    pageMiddlewares: [],
 };
 
-const mergeBotOptions = (overrides: BotOptionOverrides): IBotBuilderOptions => ({
-  ...DEFAULT_BOT_OPTIONS,
-  ...overrides,
-  pages: overrides.pages ?? [],
-  handlers: overrides.handlers ?? [],
-  middlewares: overrides.middlewares ?? [],
-  keyboards: overrides.keyboards ?? [],
-  services: overrides.services ?? {},
-  pageMiddlewares: overrides.pageMiddlewares ?? [],
-  dependencies: overrides.dependencies,
-  prisma: overrides.prisma as ActualPrismaClient | undefined,
+const mergeBotOptions = (
+    overrides: BotOptionOverrides,
+): IBotBuilderOptions => ({
+    ...DEFAULT_BOT_OPTIONS,
+    ...overrides,
+    pages: overrides.pages ?? [],
+    handlers: overrides.handlers ?? [],
+    middlewares: overrides.middlewares ?? [],
+    keyboards: overrides.keyboards ?? [],
+    services: overrides.services ?? {},
+    pageMiddlewares: overrides.pageMiddlewares ?? [],
+    dependencies: overrides.dependencies,
+    prisma: overrides.prisma as ActualPrismaClient | undefined,
 });
 
 export const createTestBotRuntime = (
-  options: CreateTestBotRuntimeOptions = {},
+    options: CreateTestBotRuntimeOptions = {},
 ): { runtime: BotRuntime; options: IBotRuntimeOptions } => {
-  const { logger, runtimeDependencies, ...botOverrides } = options;
-  const botOptions = mergeBotOptions(botOverrides);
+    const { logger, runtimeDependencies, ...botOverrides } = options;
+    const botOptions = mergeBotOptions(botOverrides);
 
-  if (!botOptions.sessionStorage) {
-    botOptions.sessionStorage = createInMemorySessionStorage();
-  }
+    if (!botOptions.sessionStorage) {
+        botOptions.sessionStorage = createInMemorySessionStorage();
+    }
 
-  if (!botOptions.prisma) {
-    botOptions.prisma = createMockPrisma() as unknown as ActualPrismaClient;
-  }
+    if (!botOptions.prisma) {
+        botOptions.prisma = createMockPrisma() as unknown as ActualPrismaClient;
+    }
 
-  const normalized = normalizeBotOptions(botOptions);
-  const runtime = new BotRuntime(
-    normalized,
-    logger ?? new Logger('TestBotRuntime'),
-    runtimeDependencies,
-  );
+    const normalized = normalizeBotOptions(botOptions);
+    const runtime = new BotRuntime(
+        normalized,
+        logger ?? new Logger('TestBotRuntime'),
+        runtimeDependencies,
+    );
 
-  return { runtime, options: normalized };
+    return { runtime, options: normalized };
 };
 
-export interface CreateTestBuilderServiceOptions {
-  prisma?: MockPrismaClient | ActualPrismaClient;
-}
-
 export const createTestBuilderService = (
-  options: CreateTestBuilderServiceOptions = {},
+    options: CreateTestBuilderServiceOptions = {},
 ): BuilderService => {
-  const prisma = options.prisma ?? (createMockPrisma() as unknown as ActualPrismaClient);
-  return new BuilderService(prisma);
+    const prisma =
+        options.prisma ?? (createMockPrisma() as unknown as ActualPrismaClient);
+    return new BuilderService(prisma);
 };

--- a/test/factories/builder.ts
+++ b/test/factories/builder.ts
@@ -1,0 +1,83 @@
+import { Logger } from '@nestjs/common';
+import type { PrismaClient as ActualPrismaClient } from '@prisma/client/extension';
+import type { IBotBuilderOptions } from '../../src/app.interface';
+import {
+  BotRuntime,
+  BotRuntimeDependencies,
+  IBotRuntimeOptions,
+  normalizeBotOptions,
+} from '../../src/builder/bot-runtime';
+import { BuilderService } from '../../src/builder/builder.service';
+import {
+  createMockPrisma,
+  PrismaClient as MockPrismaClient,
+} from '../mocks/prisma';
+import { createInMemorySessionStorage } from '../mocks/session-storage';
+
+type BotOptionOverrides = Partial<Omit<IBotBuilderOptions, 'prisma'>> & {
+  prisma?: MockPrismaClient | ActualPrismaClient;
+};
+
+export interface CreateTestBotRuntimeOptions extends BotOptionOverrides {
+  logger?: Logger;
+  runtimeDependencies?: BotRuntimeDependencies;
+}
+
+const DEFAULT_BOT_OPTIONS: IBotBuilderOptions = {
+  TG_BOT_TOKEN: 'test-token',
+  id: 'test-bot',
+  pages: [],
+  handlers: [],
+  middlewares: [],
+  keyboards: [],
+  services: {},
+  pageMiddlewares: [],
+};
+
+const mergeBotOptions = (overrides: BotOptionOverrides): IBotBuilderOptions => ({
+  ...DEFAULT_BOT_OPTIONS,
+  ...overrides,
+  pages: overrides.pages ?? [],
+  handlers: overrides.handlers ?? [],
+  middlewares: overrides.middlewares ?? [],
+  keyboards: overrides.keyboards ?? [],
+  services: overrides.services ?? {},
+  pageMiddlewares: overrides.pageMiddlewares ?? [],
+  dependencies: overrides.dependencies,
+  prisma: overrides.prisma as ActualPrismaClient | undefined,
+});
+
+export const createTestBotRuntime = (
+  options: CreateTestBotRuntimeOptions = {},
+): { runtime: BotRuntime; options: IBotRuntimeOptions } => {
+  const { logger, runtimeDependencies, ...botOverrides } = options;
+  const botOptions = mergeBotOptions(botOverrides);
+
+  if (!botOptions.sessionStorage) {
+    botOptions.sessionStorage = createInMemorySessionStorage();
+  }
+
+  if (!botOptions.prisma) {
+    botOptions.prisma = createMockPrisma() as unknown as ActualPrismaClient;
+  }
+
+  const normalized = normalizeBotOptions(botOptions);
+  const runtime = new BotRuntime(
+    normalized,
+    logger ?? new Logger('TestBotRuntime'),
+    runtimeDependencies,
+  );
+
+  return { runtime, options: normalized };
+};
+
+export interface CreateTestBuilderServiceOptions {
+  prisma?: MockPrismaClient | ActualPrismaClient;
+}
+
+export const createTestBuilderService = (
+  options: CreateTestBuilderServiceOptions = {},
+): BuilderService => {
+  const prisma = options.prisma ?? (createMockPrisma() as unknown as ActualPrismaClient);
+  return new BuilderService(prisma);
+};

--- a/test/index.ts
+++ b/test/index.ts
@@ -1,0 +1,4 @@
+export * from './mocks/node-telegram-bot-api';
+export * from './mocks/prisma';
+export * from './mocks/session-storage';
+export * from './factories/builder';

--- a/test/mocks/node-telegram-bot-api.ts
+++ b/test/mocks/node-telegram-bot-api.ts
@@ -1,0 +1,25 @@
+import type { TelegramEvents } from 'node-telegram-bot-api';
+
+type EventKey = keyof TelegramEvents;
+
+type EventListener<TEvent extends EventKey> = TelegramEvents[TEvent];
+
+export class NodeTelegramBotApiMock {
+  public readonly token: string;
+  public readonly options?: Record<string, unknown>;
+
+  public on = jest.fn(<TEvent extends EventKey>(event: TEvent, listener: EventListener<TEvent>) => {
+    return this;
+  });
+
+  public sendMessage = jest.fn(async () => undefined);
+
+  public stopPolling = jest.fn(async () => undefined);
+
+  constructor(token: string, options?: Record<string, unknown>) {
+    this.token = token;
+    this.options = options;
+  }
+}
+
+export default NodeTelegramBotApiMock;

--- a/test/mocks/node-telegram-bot-api.ts
+++ b/test/mocks/node-telegram-bot-api.ts
@@ -5,21 +5,25 @@ type EventKey = keyof TelegramEvents;
 type EventListener<TEvent extends EventKey> = TelegramEvents[TEvent];
 
 export class NodeTelegramBotApiMock {
-  public readonly token: string;
-  public readonly options?: Record<string, unknown>;
+    public readonly token: string;
+    public readonly options?: Record<string, unknown>;
 
-  public on = jest.fn(<TEvent extends EventKey>(event: TEvent, listener: EventListener<TEvent>) => {
-    return this;
-  });
+    public on = jest.fn(
+        <TEvent extends EventKey>(
+            event: TEvent,
+            listener: EventListener<TEvent>,
+        ) => {
+            return this;
+        },
+    );
 
-  public sendMessage = jest.fn(async () => undefined);
+    public sendMessage = jest.fn(async () => undefined);
 
-  public stopPolling = jest.fn(async () => undefined);
+    public stopPolling = jest.fn(async () => undefined);
 
-  constructor(token: string, options?: Record<string, unknown>) {
-    this.token = token;
-    this.options = options;
-  }
+    constructor(token: string, options?: Record<string, unknown>) {
+        this.token = token;
+        this.options = options;
+    }
 }
-
 export default NodeTelegramBotApiMock;

--- a/test/mocks/prisma.ts
+++ b/test/mocks/prisma.ts
@@ -1,0 +1,50 @@
+import type { PrismaClient as ActualPrismaClient } from '@prisma/client/extension';
+
+export type PrismaClient = Partial<ActualPrismaClient> & {
+  user: {
+    upsert: jest.Mock<Promise<unknown>, [unknown]>;
+  };
+  stepState: {
+    findUnique: jest.Mock<Promise<unknown | null>, [unknown]>;
+    create: jest.Mock<Promise<unknown>, [unknown]>;
+    update: jest.Mock<Promise<unknown>, [unknown]>;
+  };
+  formEntry: {
+    upsert: jest.Mock<Promise<unknown>, [unknown]>;
+  };
+};
+
+const mergeDelegates = <T extends Record<string, jest.Mock>>(defaults: T, overrides?: Partial<T>): T => ({
+  ...defaults,
+  ...(overrides ?? {}),
+});
+
+export type MockPrismaClient = PrismaClient;
+
+export const createMockPrisma = (overrides: Partial<MockPrismaClient> = {}): MockPrismaClient => {
+  const prisma: MockPrismaClient = {
+    ...(overrides as MockPrismaClient),
+    user: mergeDelegates(
+      {
+        upsert: jest.fn(),
+      },
+      overrides.user,
+    ),
+    stepState: mergeDelegates(
+      {
+        findUnique: jest.fn(),
+        create: jest.fn(),
+        update: jest.fn(),
+      },
+      overrides.stepState,
+    ),
+    formEntry: mergeDelegates(
+      {
+        upsert: jest.fn(),
+      },
+      overrides.formEntry,
+    ),
+  };
+
+  return prisma;
+};

--- a/test/mocks/prisma.ts
+++ b/test/mocks/prisma.ts
@@ -1,50 +1,54 @@
 import type { PrismaClient as ActualPrismaClient } from '@prisma/client/extension';
 
 export type PrismaClient = Partial<ActualPrismaClient> & {
-  user: {
-    upsert: jest.Mock<Promise<unknown>, [unknown]>;
-  };
-  stepState: {
-    findUnique: jest.Mock<Promise<unknown | null>, [unknown]>;
-    create: jest.Mock<Promise<unknown>, [unknown]>;
-    update: jest.Mock<Promise<unknown>, [unknown]>;
-  };
-  formEntry: {
-    upsert: jest.Mock<Promise<unknown>, [unknown]>;
-  };
+    user: {
+        upsert: jest.Mock<Promise<unknown>, [unknown]>;
+    };
+    stepState: {
+        findUnique: jest.Mock<Promise<unknown | null>, [unknown]>;
+        create: jest.Mock<Promise<unknown>, [unknown]>;
+        update: jest.Mock<Promise<unknown>, [unknown]>;
+    };
+    formEntry: {
+        upsert: jest.Mock<Promise<unknown>, [unknown]>;
+    };
 };
-
-const mergeDelegates = <T extends Record<string, jest.Mock>>(defaults: T, overrides?: Partial<T>): T => ({
-  ...defaults,
-  ...(overrides ?? {}),
-});
-
 export type MockPrismaClient = PrismaClient;
 
-export const createMockPrisma = (overrides: Partial<MockPrismaClient> = {}): MockPrismaClient => {
-  const prisma: MockPrismaClient = {
-    ...(overrides as MockPrismaClient),
-    user: mergeDelegates(
-      {
-        upsert: jest.fn(),
-      },
-      overrides.user,
-    ),
-    stepState: mergeDelegates(
-      {
-        findUnique: jest.fn(),
-        create: jest.fn(),
-        update: jest.fn(),
-      },
-      overrides.stepState,
-    ),
-    formEntry: mergeDelegates(
-      {
-        upsert: jest.fn(),
-      },
-      overrides.formEntry,
-    ),
-  };
+const mergeDelegates = <T extends Record<string, jest.Mock>>(
+    defaults: T,
+    overrides?: Partial<T>,
+): T => ({
+    ...defaults,
+    ...(overrides ?? {}),
+});
 
-  return prisma;
+export const createMockPrisma = (
+    overrides: Partial<MockPrismaClient> = {},
+): MockPrismaClient => {
+    const prisma: MockPrismaClient = {
+        ...(overrides as MockPrismaClient),
+        user: mergeDelegates(
+            {
+                upsert: jest.fn(),
+            },
+            overrides.user,
+        ),
+        stepState: mergeDelegates(
+            {
+                findUnique: jest.fn(),
+                create: jest.fn(),
+                update: jest.fn(),
+            },
+            overrides.stepState,
+        ),
+        formEntry: mergeDelegates(
+            {
+                upsert: jest.fn(),
+            },
+            overrides.formEntry,
+        ),
+    };
+
+    return prisma;
 };

--- a/test/mocks/session-storage.ts
+++ b/test/mocks/session-storage.ts
@@ -1,0 +1,30 @@
+import TelegramBot = require('node-telegram-bot-api');
+import type { IBotSessionStorage } from '../../src/app.interface';
+
+export type BotSessionStorageState<TState> = Record<string, TState>;
+
+export type MockSessionStorage<TState> = IBotSessionStorage<TState> & {
+  store: Map<string, TState>;
+};
+
+export const createInMemorySessionStorage = <TState>(
+  initialState: Partial<BotSessionStorageState<TState>> = {},
+): MockSessionStorage<TState> => {
+  const store = new Map<string, TState>();
+  for (const [key, value] of Object.entries(initialState)) {
+    store.set(key, value as TState);
+  }
+
+  const storage: MockSessionStorage<TState> = {
+    store,
+    get: jest.fn(async (chatId: TelegramBot.ChatId) => store.get(chatId.toString())),
+    set: jest.fn(async (chatId: TelegramBot.ChatId, state: TState) => {
+      store.set(chatId.toString(), state);
+    }),
+    delete: jest.fn(async (chatId: TelegramBot.ChatId) => {
+      store.delete(chatId.toString());
+    }),
+  };
+
+  return storage;
+};

--- a/test/mocks/session-storage.ts
+++ b/test/mocks/session-storage.ts
@@ -1,30 +1,31 @@
 import TelegramBot = require('node-telegram-bot-api');
-import type { IBotSessionStorage } from '../../src/app.interface';
+import type { IBotSessionStorage } from '../../src';
 
 export type BotSessionStorageState<TState> = Record<string, TState>;
-
 export type MockSessionStorage<TState> = IBotSessionStorage<TState> & {
-  store: Map<string, TState>;
+    store: Map<string, TState>;
 };
 
 export const createInMemorySessionStorage = <TState>(
-  initialState: Partial<BotSessionStorageState<TState>> = {},
+    initialState: Partial<BotSessionStorageState<TState>> = {},
 ): MockSessionStorage<TState> => {
-  const store = new Map<string, TState>();
-  for (const [key, value] of Object.entries(initialState)) {
-    store.set(key, value as TState);
-  }
+    const store = new Map<string, TState>();
+    for (const [key, value] of Object.entries(initialState)) {
+        store.set(key, value as TState);
+    }
 
-  const storage: MockSessionStorage<TState> = {
-    store,
-    get: jest.fn(async (chatId: TelegramBot.ChatId) => store.get(chatId.toString())),
-    set: jest.fn(async (chatId: TelegramBot.ChatId, state: TState) => {
-      store.set(chatId.toString(), state);
-    }),
-    delete: jest.fn(async (chatId: TelegramBot.ChatId) => {
-      store.delete(chatId.toString());
-    }),
-  };
+    const storage: MockSessionStorage<TState> = {
+        store,
+        get: jest.fn(async (chatId: TelegramBot.ChatId) =>
+            store.get(chatId.toString()),
+        ),
+        set: jest.fn(async (chatId: TelegramBot.ChatId, state: TState) => {
+            store.set(chatId.toString(), state);
+        }),
+        delete: jest.fn(async (chatId: TelegramBot.ChatId) => {
+            store.delete(chatId.toString());
+        }),
+    };
 
-  return storage;
+    return storage;
 };

--- a/test/setup/jest.setup.ts
+++ b/test/setup/jest.setup.ts
@@ -2,6 +2,16 @@ import 'reflect-metadata';
 
 type NestTesting = typeof import('@nestjs/testing');
 
+jest.mock('node-telegram-bot-api');
+
+const ORIGINAL_ENV = { ...process.env };
+const DEFAULT_TEST_ENV: NodeJS.ProcessEnv = {
+  ...ORIGINAL_ENV,
+  NODE_ENV: 'test',
+  TZ: 'UTC',
+  TG_BOT_TOKEN: process.env.TG_BOT_TOKEN ?? 'test-token',
+};
+
 jest.mock('@nestjs/testing', (): NestTesting => {
   const actual: NestTesting = jest.requireActual('@nestjs/testing');
   const patched = actual.Test.createTestingModule as typeof actual.Test.createTestingModule & {
@@ -25,10 +35,16 @@ jest.mock('@nestjs/testing', (): NestTesting => {
 });
 
 beforeEach(() => {
+  process.env = { ...DEFAULT_TEST_ENV } as NodeJS.ProcessEnv;
   jest.clearAllMocks();
 });
 
 afterEach(() => {
   jest.clearAllTimers();
   jest.useRealTimers();
+  process.env = { ...DEFAULT_TEST_ENV } as NodeJS.ProcessEnv;
+});
+
+afterAll(() => {
+  process.env = { ...ORIGINAL_ENV } as NodeJS.ProcessEnv;
 });

--- a/test/setup/jest.setup.ts
+++ b/test/setup/jest.setup.ts
@@ -6,45 +6,46 @@ jest.mock('node-telegram-bot-api');
 
 const ORIGINAL_ENV = { ...process.env };
 const DEFAULT_TEST_ENV: NodeJS.ProcessEnv = {
-  ...ORIGINAL_ENV,
-  NODE_ENV: 'test',
-  TZ: 'UTC',
-  TG_BOT_TOKEN: process.env.TG_BOT_TOKEN ?? 'test-token',
+    ...ORIGINAL_ENV,
+    NODE_ENV: 'test',
+    TZ: 'UTC',
+    TG_BOT_TOKEN: process.env.TG_BOT_TOKEN ?? 'test-token',
 };
 
 jest.mock('@nestjs/testing', (): NestTesting => {
-  const actual: NestTesting = jest.requireActual('@nestjs/testing');
-  const patched = actual.Test.createTestingModule as typeof actual.Test.createTestingModule & {
-    __jestPatched?: boolean;
-  };
-
-  if (!patched.__jestPatched) {
-    const originalCreateTestingModule = patched.bind(actual.Test);
-    const wrappedCreateTestingModule = (
-      ...args: Parameters<typeof originalCreateTestingModule>
-    ) => {
-      jest.useFakeTimers();
-      return originalCreateTestingModule(...args);
+    const actual: NestTesting = jest.requireActual('@nestjs/testing');
+    const patched = actual.Test
+        .createTestingModule as typeof actual.Test.createTestingModule & {
+        __jestPatched?: boolean;
     };
 
-    (wrappedCreateTestingModule as typeof patched).__jestPatched = true;
-    actual.Test.createTestingModule = wrappedCreateTestingModule;
-  }
+    if (!patched.__jestPatched) {
+        const originalCreateTestingModule = patched.bind(actual.Test);
+        const wrappedCreateTestingModule = (
+            ...args: Parameters<typeof originalCreateTestingModule>
+        ) => {
+            jest.useFakeTimers();
+            return originalCreateTestingModule(...args);
+        };
 
-  return actual;
+        (wrappedCreateTestingModule as typeof patched).__jestPatched = true;
+        actual.Test.createTestingModule = wrappedCreateTestingModule;
+    }
+
+    return actual;
 });
 
 beforeEach(() => {
-  process.env = { ...DEFAULT_TEST_ENV } as NodeJS.ProcessEnv;
-  jest.clearAllMocks();
+    process.env = { ...DEFAULT_TEST_ENV } as NodeJS.ProcessEnv;
+    jest.clearAllMocks();
 });
 
 afterEach(() => {
-  jest.clearAllTimers();
-  jest.useRealTimers();
-  process.env = { ...DEFAULT_TEST_ENV } as NodeJS.ProcessEnv;
+    jest.clearAllTimers();
+    jest.useRealTimers();
+    process.env = { ...DEFAULT_TEST_ENV } as NodeJS.ProcessEnv;
 });
 
 afterAll(() => {
-  process.env = { ...ORIGINAL_ENV } as NodeJS.ProcessEnv;
+    process.env = { ...ORIGINAL_ENV } as NodeJS.ProcessEnv;
 });

--- a/tsconfig.spec.json
+++ b/tsconfig.spec.json
@@ -1,9 +1,9 @@
 {
-  "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "types": ["jest", "node"],
-    "sourceMap": true
-  },
-  "include": ["src/**/*.ts", "test/**/*.ts"],
-  "exclude": ["node_modules", "dist"]
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "types": ["jest", "node"],
+        "sourceMap": true
+    },
+    "include": ["src/**/*.ts", "test/**/*.ts"],
+    "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
## Summary
- add a reusable node-telegram-bot-api stub and register it as a manual Jest mock
- provide Prisma and session storage mocks plus test factories for building runtimes
- export the new helpers and standardise Jest setup environment configuration

## Testing
- npm test -- --runTestsByPath

------
https://chatgpt.com/codex/tasks/task_e_68d7d12cc2b88328aa54b8478df3f4f8