### PR TITLE
Add SessionManager normalization tests

### DIFF
--- a/test/runtime/session-manager.spec.ts
+++ b/test/runtime/session-manager.spec.ts
@@ -1,0 +1,94 @@
+import TelegramBot = require('node-telegram-bot-api');
+import {
+    SessionManager,
+    IChatSessionState,
+} from '../../src/builder/runtime/session-manager';
+import { IBotSessionState } from '../../src/app.interface';
+import { createInMemorySessionStorage } from '../mocks/session-storage';
+
+describe('SessionManager', () => {
+    const chatId = 12345;
+
+    it('normalizes missing session into an empty state and caches the result', async () => {
+        const storage = createInMemorySessionStorage<IChatSessionState | IBotSessionState>();
+        const manager = new SessionManager({ sessionStorage: storage });
+
+        const session = await manager.getSession(chatId);
+
+        expect(session).toEqual({ pageId: undefined, data: {} });
+        expect(storage.get).toHaveBeenCalledTimes(1);
+
+        const cached = await manager.getSession(chatId);
+
+        expect(cached).toBe(session);
+        expect(storage.get).toHaveBeenCalledTimes(1);
+    });
+
+    it('wraps legacy session data and caches the normalized result', async () => {
+        const legacyState: IBotSessionState = { foo: 'bar' };
+        const storage = createInMemorySessionStorage<IChatSessionState | IBotSessionState>({
+            [chatId.toString()]: legacyState,
+        });
+        const manager = new SessionManager({ sessionStorage: storage });
+
+        const session = await manager.getSession(chatId);
+
+        expect(session).toEqual({ pageId: undefined, data: legacyState });
+        expect(session.data).toBe(legacyState);
+        expect(storage.get).toHaveBeenCalledTimes(1);
+
+        const cached = await manager.getSession(chatId);
+
+        expect(cached).toBe(session);
+        expect(storage.get).toHaveBeenCalledTimes(1);
+    });
+
+    it('ensures chat session state includes data and caches the patched value', async () => {
+        const user = {
+            id: 1,
+            is_bot: false,
+            first_name: 'Tester',
+        } as TelegramBot.User;
+        const stored = {
+            pageId: 'page-1',
+            data: undefined,
+            user,
+        } as unknown as IChatSessionState;
+        const storage = createInMemorySessionStorage<IChatSessionState | IBotSessionState>({
+            [chatId.toString()]: stored,
+        });
+        const manager = new SessionManager({ sessionStorage: storage });
+
+        const session = await manager.getSession(chatId);
+
+        expect(session.pageId).toBe('page-1');
+        expect(session.user).toBe(user);
+        expect(session.data).toEqual({});
+        expect(storage.get).toHaveBeenCalledTimes(1);
+
+        const cached = await manager.getSession(chatId);
+
+        expect(cached).toBe(session);
+        expect(storage.get).toHaveBeenCalledTimes(1);
+    });
+
+    it('updates cache and storage when saving a session', async () => {
+        const storage = createInMemorySessionStorage<IChatSessionState | IBotSessionState>();
+        const manager = new SessionManager({ sessionStorage: storage });
+
+        const session: IChatSessionState = {
+            pageId: 'page-2',
+            data: { answer: 42 },
+        };
+
+        await manager.saveSession(chatId, session);
+
+        expect(storage.set).toHaveBeenCalledTimes(1);
+        expect(storage.set).toHaveBeenCalledWith(chatId, session);
+
+        const cached = await manager.getSession(chatId);
+
+        expect(cached).toBe(session);
+        expect(storage.get).not.toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
## Summary
- add tests covering SessionManager normalization for empty, legacy, and partial states
- verify SessionManager caching and save behavior when using in-memory storage

## Testing
- npm test -- session-manager

------
https://chatgpt.com/codex/tasks/task_e_68d7ee3136f48328bbee0be3b8b284f1