### PR TITLE
Handle page redirects when persisting session state

### DIFF
--- a/src/builder/runtime/page-navigator.ts
+++ b/src/builder/runtime/page-navigator.ts
@@ -288,7 +288,7 @@ export class PageNavigator {
     public async renderPage(
         page: IBotPage,
         context: IBotBuilderContext,
-    ): Promise<void> {
+    ): Promise<TBotPageIdentifier | undefined> {
         const middlewareResult = await this.executePageMiddlewares(
             page,
             context,
@@ -307,8 +307,7 @@ export class PageNavigator {
                         this.options.logger.log(
                             `Redirecting chat ${context.chatId} from "${page.id}" to "${redirectPage.id}" due to middleware result`,
                         );
-                        await this.renderPage(redirectPage, context);
-                        return;
+                        return await this.renderPage(redirectPage, context);
                     }
 
                     this.options.logger.warn(
@@ -326,7 +325,7 @@ export class PageNavigator {
             );
 
             await this.options.bot.sendMessage(context.chatId, message);
-            return;
+            return page.id;
         }
 
         const payload = await this.resolvePageContent(page.content, context);
@@ -343,6 +342,8 @@ export class PageNavigator {
         await this.options.bot.sendMessage(context.chatId, payload.text, {
             ...options,
         });
+
+        return page.id;
     }
 
     /**


### PR DESCRIPTION
## Summary
- return the final rendered page id from the page navigator so middleware redirects are visible to callers
- update bot runtime flows to persist redirected page ids in both the session cache and Prisma step state
- cover redirect scenarios with new message flow specs for initial render and next-page advancement

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d80b0c27e08328b7cac06e5b2f9dd1