### PR TITLE
Allow pages without content

### DIFF
--- a/src/app.interface.ts
+++ b/src/app.interface.ts
@@ -91,7 +91,7 @@ export type TBotPageValidateFn = (
 
 export interface IBotPage {
     id: TBotPageIdentifier;
-    content: TBotPageContent;
+    content?: TBotPageContent;
     onValid?: TBotPageOnValid;
     next?: TBotPageNextResolver;
     validate?: TBotPageValidateFn;

--- a/src/builder/runtime/page-navigator.ts
+++ b/src/builder/runtime/page-navigator.ts
@@ -328,6 +328,10 @@ export class PageNavigator {
             return page.id;
         }
 
+        if (page.content === undefined) {
+            return page.id;
+        }
+
         const payload = await this.resolvePageContent(page.content, context);
         const keyboard = await this.resolveKeyboard(page.id, context);
 

--- a/test/runtime/page-navigator.spec.ts
+++ b/test/runtime/page-navigator.spec.ts
@@ -160,4 +160,21 @@ describe('PageNavigator', () => {
             }),
         );
     });
+
+    it('skips sending a message when a page has no content', async () => {
+        const page: IBotPage = {
+            id: 'silent-page',
+        };
+
+        const navigator = new PageNavigator({
+            bot: bot as unknown as TelegramBot,
+            logger,
+        });
+
+        navigator.registerPages([page]);
+
+        await navigator.renderPage(page, createContext());
+
+        expect(bot.sendMessage).not.toHaveBeenCalled();
+    });
 });


### PR DESCRIPTION
## Summary
- allow bot pages to omit content in their definitions
- skip message rendering when navigating to a page without content
- cover the no-content scenario with runtime navigator tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d9160d4b688328bde4ea845afc291b